### PR TITLE
[openshift] Lower memory limit to 1GB

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -167,7 +167,7 @@ objects:
             requests:
               memory: "512Mi"
             limits:
-              memory: "2048Mi"
+              memory: "1024Mi"
         restartPolicy: Always
     test: false
     triggers:


### PR DESCRIPTION
So we can scale to 30 workers