### PR TITLE
[WIP] Change the recommendation logic

### DIFF
--- a/cucoslib/dispatcher/nodes.yml
+++ b/cucoslib/dispatcher/nodes.yml
@@ -348,6 +348,15 @@
         encryption: false
         versioned: false
 
+    - name: 'S3UserProfileStore'
+      import: 'cucoslib.storages'
+      configuration:
+        <<: *configurationS3
+        bucket_name: 'janus-json-data'
+        region_name: 'us-east-1'
+        encryption: false
+        versioned: false
+
     - name: 'S3Readme'
       import: 'cucoslib.storages'
       configuration:

--- a/cucoslib/graphutils.py
+++ b/cucoslib/graphutils.py
@@ -7,6 +7,8 @@ GREMLIN_SERVER_URL_REST = "http://{host}:{port}".format\
                            (host=os.environ.get("BAYESIAN_GREMLIN_HTTP_SERVICE_HOST", "localhost"),
                             port=os.environ.get("BAYESIAN_GREMLIN_HTTP_SERVICE_PORT", "8182"))
 
+PGM_REST_URL = os.getenv('PGM_REST_URL', 'http://kronos-kattappa-0237.dev.rdu2c.fabric8.io/api/v1/kronos_score')
+JANUS_MODEL_REST_URL = os.getenv('JANUS_MODEL_REST_URL', 'http://janus-demo-janus.dev.rdu2c.fabric8.io/api/v1/janus')
 
 def get_stack_usage_data_graph(components):
     components_with_usage_data = 0

--- a/cucoslib/storages/__init__.py
+++ b/cucoslib/storages/__init__.py
@@ -10,6 +10,7 @@ from .s3_package_data import S3PackageData
 from .s3_manifests import S3Manifests
 from .s3_mavenindex import S3MavenIndex
 from .s3_owaspdepcheck import S3OWASPDepCheck
+from .s3_userprofilestore import S3UserProfileStore
 from .s3_readme import S3Readme
 from .s3_snyk import S3Snyk
 from .s3_gh_manifests import S3GitHubManifestMetadata

--- a/cucoslib/storages/s3_userprofilestore.py
+++ b/cucoslib/storages/s3_userprofilestore.py
@@ -1,0 +1,11 @@
+"""Import AmazonS3"""
+from . import AmazonS3
+
+class S3UserProfileStore(AmazonS3):
+    """An Adapter Class to handle storage of User Profile information to S3"""
+    def store_in_bucket(self, content):
+        """Stores the User Profile information into S3 Buckets"""
+        email = content.get('email')
+        folder = 'new_user_profile'
+        key = folder + '/' + email + '.json'
+        self.store_dict(content, key)


### PR DESCRIPTION
graphaggregator.py
1. Read user profile information as sent from api_v1.py's StackAnalysis Call
2. Add the logic to store the user profile information to Amazon S3 bucket
3. Modify the return object with the addition of user profile information to be able to use in recommender flow

recommender.py
1. Introduce a new execute flow for the modified logic of recommendation StackAnalysis
2. Setup a function to call Janus model and pass user profile information to get the user persona information
3. Use the user persona information and call the PGM function with the normalized manifest data to get the relevant packages
4. Call Gremlin with a new query by passing ecosystem and packages list received from PGM to get their version information

Fixes #65