### PR TITLE
Pin version of scancode, because upsteam is broken. 

### DIFF
--- a/hack/install_scancode.sh
+++ b/hack/install_scancode.sh
@@ -4,7 +4,7 @@
 # But we can stabilize to final 2.0.0 once it's released - see the commented code below.
 
 cd /opt
-git clone --depth 1 https://github.com/nexB/scancode-toolkit.git
+git clone https://github.com/nexB/scancode-toolkit.git
 cd scancode-toolkit
 
 # scancode-toolkit has broken dependencies. This commit it working

--- a/hack/install_scancode.sh
+++ b/hack/install_scancode.sh
@@ -7,6 +7,10 @@ cd /opt
 git clone --depth 1 https://github.com/nexB/scancode-toolkit.git
 cd scancode-toolkit
 
+# scancode-toolkit has broken dependencies. This commit it working
+# Workaround until upstream is fixed
+git checkout 1fea769
+
 #RELEASE='2.0.0'
 #RC="rc2"
 #mkdir -p $SCANCODE_PATH


### PR DESCRIPTION
This is workaround until upsteam is fixed
I published fix in upstream repository: https://github.com/nexB/scancode-toolkit/pull/671