### PR TITLE
Fix tempdir usage

### DIFF
--- a/f8a_worker/workers/git_stats.py
+++ b/f8a_worker/workers/git_stats.py
@@ -22,7 +22,7 @@ class GitStats(BaseTask):
   
         :param url: url to the git repo
         """
-        with tempdir as tmp_dir:
+        with tempdir() as tmp_dir:
             git = Git.clone(url, tmp_dir)
             # nice notebook to check at:
             #   http://nbviewer.jupyter.org/github/tarmstrong/code-analysis/blob/master/IPythonReviewTime.ipynb


### PR DESCRIPTION
Fixes:

```
File "/usr/lib/python3.4/site-packages/f8a_worker/workers/git_stats.py", line 132, in execute
     master_log = self._get_log(arguments['url'])
File "/usr/lib/python3.4/site-packages/f8a_worker/workers/git_stats.py", line 25, in _get_log
     with tempdir as tmp_dir:
AttributeError: __exit__
```