### PR TITLE
Python egg

### DIFF
--- a/f8a_worker/process.py
+++ b/f8a_worker/process.py
@@ -152,7 +152,7 @@ class Archive(object):
     def extract(target, dest):
         """ Detects archive type and extracts it """
         tar = Archive.TarMatcher.search(target)
-        if target.endswith(('.zip', '.whl', '.jar', '.nupkg')):
+        if target.endswith(('.zip', '.whl', '.egg', '.jar', '.nupkg')):
             return Archive.extract_zip(target, dest)
         elif target.endswith('.gem'):
             return Archive.extract_gem(target, dest)

--- a/f8a_worker/workers/license.py
+++ b/f8a_worker/workers/license.py
@@ -17,7 +17,7 @@ class LicenseCheckTask(BaseTask):
     SCANCODE_LICENSE_SCORE = '20'  # scancode's default is 0
     SCANCODE_TIMEOUT = '120'  # scancode's default is 120
     SCANCODE_PROCESSES = '1'  # scancode's default is 1
-    SCANCODE_IGNORE = ['*.so', '*.dll']  # don't scan binaries
+    SCANCODE_IGNORE = ['*.pyc', '*.so', '*.dll']  # don't scan binaries
 
     @staticmethod
     def process_output(data):


### PR DESCRIPTION
- Treat Python eggs as zip archives (fixes #112 )
- [LicenseCheckTask] ignore pyc files





