### PR TITLE
PypiSolver - compatible release operator (~=)

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -153,10 +153,12 @@ class TestSolver(object):
     def test_pypi_solver(self, pypi):
         solver = get_ecosystem_solver(pypi)
         deps = ['django == 1.9.10',
-                'pymongo >=3.0, <3.2.2']
+                'pymongo >=3.0, <3.2.2',
+                'six~=1.7.1']
         out = solver.solve(deps)
         assert out == {'django': '1.9.10',
-                       'pymongo': '3.2.1'}
+                       'pymongo': '3.2.1',
+                       'six': '1.7.3'}
 
     def test_rubygems_solver(self, rubygems):
         solver = get_ecosystem_solver(rubygems)


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0440/#compatible-release

This probably is already implemented somewhere in [pip](https://pypi.python.org/pypi/pip), but I haven't found it (to reuse that code).