### PR TITLE
Remove hack/pip-requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,14 +38,10 @@ RUN mkdir /tmp/binwalk/ && \
     python /tmp/binwalk/setup.py install && \
     rm -rf /tmp/binwalk/
 
-# Install non-Mercator python native deps
-COPY hack/pip-requirements.txt /tmp/install_deps/
-
 # Fixes:
 # 'pip install --upgrade wheel': http://stackoverflow.com/questions/14296531
 # 'install --no-binary :all: protobuf': https://github.com/google/protobuf/issues/1296
 RUN pip3 install --upgrade pip && pip install --upgrade wheel && \
-    pip3 install -r /tmp/install_deps/pip-requirements.txt && \
     pip3 install alembic psycopg2 git+git://github.com/msrb/kombu@sqs-conn#egg=kombu && \
     pip3 install --upgrade --no-binary :all: protobuf
 

--- a/hack/pip-requirements.txt
+++ b/hack/pip-requirements.txt
@@ -1,6 +1,0 @@
-# Non-RPM f8a-lib requirements (from setup.py & f8a_worker/process.py)
-# Mercator has its own requirements.txt
-# TODO: remove this once we move to mercator-go as this will be handled by RPM
-# we leave it here not to install go ecosystem on all images as it is
-# actually needed only by worker
-gofedlib


### PR DESCRIPTION
I can't find what actually needs gofedlib.
If mercator-go, then the requirement should go into https://github.com/fabric8-analytics/mercator-go/blob/master/mercator.spec
If some worker, then it should go into requirements.in/txt