### PR TITLE
[hack/patches/scancode_ignore_binary.patch] skip files bigger than 1MB

### DIFF
--- a/hack/patches/scancode_ignore_binary.patch
+++ b/hack/patches/scancode_ignore_binary.patch
@@ -8,7 +8,7 @@ diff -up scancode-toolkit-2.0.1/src/scancode/cli.py.ignore-binary scancode-toolk
      infos['path'] = rel_path
      infos.update(scan_infos(abs_path, diag=diag))
  
-+    if any((infos['is_binary'], infos['is_media'])):
++    if any((infos['is_binary'], infos['is_media'], infos['size'] > 1000000)):
 +        return True, rel_path
 +
      success = True


### PR DESCRIPTION
Dirty work-around to #172 