### PR TITLE
[LibrariesIoTask] Use regexp for more general match

### DIFF
--- a/f8a_worker/workers/libraries_io.py
+++ b/f8a_worker/workers/libraries_io.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from re import compile as re_compile
 from requests import get
 
 from f8a_worker.base import BaseTask
@@ -12,7 +13,7 @@ class LibrariesIoTask(BaseTask):
 
     @staticmethod
     def _get_list_term_description(page, term_name):
-        tag = page.find(string='\n{}\n'.format(term_name))
+        tag = page.find(string=re_compile(r'^\s*{}\s*$'.format(term_name)))
         return tag.find_next('dd')
 
     def _get_list_term_description_text(self, page, term_name):

--- a/tests/workers/test_libraries_io.py
+++ b/tests/workers/test_libraries_io.py
@@ -9,7 +9,7 @@ class TestLibrariesIoTask(object):
          {'ecosystem': 'maven', 'name': 'org.jboss.netty:netty'},
          {'ecosystem': 'npm', 'name': 'grunt'},
          {'ecosystem': 'pypi', 'name': 'Flask'},
-         {'ecosystem': 'nuget', 'name': 'Newtonsoft.Json'}
+         {'ecosystem': 'nuget', 'name': 'NPOI'}
     ])
     def test_execute(self, args):
         task = LibrariesIoTask.create_test_instance(task_name='libraries_io')


### PR DESCRIPTION
The task was failing because of some white spaces around `'Total releases'`  in
https://libraries.io/nuget/NPOI and around `'Dependent projects'` in
https://libraries.io/nuget/Microsoft.jQuery.Unobtrusive.Ajax