### PR TITLE
[hack/install_deps_rpm.sh] install http-parser from koji

### DIFF
--- a/hack/install_deps_rpm.sh
+++ b/hack/install_deps_rpm.sh
@@ -35,7 +35,10 @@ DIGESTER='ssdeep'
 BREWUTILS="python2-brewutils"
 
 # mercator-go
-MERCATOR="mercator"
+# Requires nodejs, which requires http-parser, which is not in EPEL repo due to https://bugzilla.redhat.com/show_bug.cgi?id=1481008
+# This http-parser hack can be removed once Centos-7.4 image is out
+MERCATOR="https://kojipkgs.fedoraproject.org/packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
+          mercator"
 
 # CodeMetricsTask - it requires python-pip, since we'll be installing mccabe for both Python 2 and 3
 # CODE_METRICS="cloc python-pip"


### PR DESCRIPTION
To work-around the following problem:
 
```sh
$ docker run -ti centos:7 bash -c "yum install -y epel-release && yum install nodejs"
--> Finished Dependency Resolution
Error: Package: 1:nodejs-6.11.1-1.el7.x86_64 (epel)
           Requires: libhttp_parser.so.2()(64bit)
Error: Package: 1:nodejs-6.11.1-1.el7.x86_64 (epel)
           Requires: http-parser >= 2.7.0
```

See also https://bugzilla.redhat.com/show_bug.cgi?id=1481008