### PR TITLE
Version in nupkg download url needs to be lowercase

### DIFF
--- a/f8a_worker/process.py
+++ b/f8a_worker/process.py
@@ -382,7 +382,7 @@ class IndianaJones(object):
             git = Git.create_git(target_dir)
             file_url = '{url}{artifact}.{version}.nupkg'.format(url=ecosystem.fetch_url,
                                                                 artifact=artifact.lower(),
-                                                                version=version)
+                                                                version=version.lower())
             local_filename = IndianaJones.download_file(file_url, target_dir)
             if local_filename is None:
                 raise RuntimeError("Unable to download: %s" % file_url)


### PR DESCRIPTION
examples:
Bootstrap 3.3.6-jQuery3 -> bootstrap.3.3.6-jquery3.nupkg
Common.Logging 3.4.1-RC1 -> common.logging.3.4.1-rc1.nupkg