### PR TITLE
Remove 'git+' from url before we 'git clone' it

### DIFF
--- a/f8a_worker/process.py
+++ b/f8a_worker/process.py
@@ -57,6 +57,9 @@ class Git(object):
         :return: instance of Git()
         """
         cls.config()
+        # git clone doesn't understand urls starting with: git+ssh, git+http, git+https
+        if url.startswith('git+'):
+            url = url[len('git+'):]
         cmd = ["git", "clone", url, path]
         if depth is not None:
             cmd.extend(["--depth", depth])


### PR DESCRIPTION
'git clone' doesn't understand urls starting with: git+ssh, git+http, git+https
and fails with:
fatal: Unable to find remote helper for 'git+https'

[example](https://github.com/alleyinteractive/sasslint-webpack-plugin/blob/master/package.json#L17) of such url