### PR TITLE
[test_libraries_io] mark TestLibrariesIoTask as expected to fail

### DIFF
--- a/tests/workers/test_libraries_io.py
+++ b/tests/workers/test_libraries_io.py
@@ -3,6 +3,9 @@ import pytest
 from f8a_worker.workers import LibrariesIoTask
 
 
+# expected to fail, since getting libraries.io web page quite often results in
+# unpredictably incomplete html code
+@pytest.mark.xfail
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestLibrariesIoTask(object):
     @pytest.mark.parametrize('args', [


### PR DESCRIPTION
examples of such fail:
https://cucos-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/fabric8-analytics-worker-master/478/console
https://cucos-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/fabric8-analytics-worker-PRs/370/console
https://cucos-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/fabric8-analytics-worker-PRs/373/console