### PR TITLE
[IndianaJones.download_file()] rstrip trailing slash

### DIFF
--- a/f8a_worker/process.py
+++ b/f8a_worker/process.py
@@ -209,6 +209,8 @@ class Archive(object):
 class IndianaJones(object):
     @staticmethod
     def download_file(url, target_dir=None, name=None):
+        if url.endswith('/'):
+            url = url[:-1]
         local_filename = name or url.split('/')[-1]
 
         logger.debug("fetching artifact from: %s", url)


### PR DESCRIPTION
Otherwise Indy fails to download e.g. http://aws.amazon.com/apache2.0/