### PR TITLE
Rename cucos-lib-tests to worker-tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node('docker') {
         dockerCleanup()
         docker.build(image.id, '--pull --no-cache .')
         sh "docker tag ${image.id} registry.devshift.net/${image.id}"
-        docker.build('cucos-lib-tests', '--no-cache -f Dockerfile.tests .')
+        docker.build('worker-tests', '--no-cache -f Dockerfile.tests .')
     }
 
     stage('Unit Tests') {


### PR DESCRIPTION
That's the test image name we [use in runtest.sh](https://github.com/fabric8-analytics/fabric8-analytics-worker/blob/master/runtest.sh#L16)

Or maybe I don't understand how it works now ?