### PR TITLE
[PypiDependencyParser] support arbitrary-equality operator

### DIFF
--- a/f8a_worker/solver.py
+++ b/f8a_worker/solver.py
@@ -393,6 +393,10 @@ class PypiDependencyParser(DependencyParser):
                 else:
                     raise ValueError('%r must not be used with %r' % (spec.operator, spec.version))
                 return [('>=', spec.version), ('<', '.'.join(version))]
+            # https://www.python.org/dev/peps/pep-0440/#arbitrary-equality
+            # Use of this operator is heavily discouraged, so just convert it to 'Version matching'
+            elif spec.operator == '===':
+                return '==', spec.version
             else:
                 return spec.operator, spec.version
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -154,11 +154,13 @@ class TestSolver(object):
         solver = get_ecosystem_solver(pypi)
         deps = ['django == 1.9.10',
                 'pymongo >=3.0, <3.2.2',
-                'six~=1.7.1']
+                'six~=1.7.1',
+                'requests===2.16.2']
         out = solver.solve(deps)
         assert out == {'django': '1.9.10',
                        'pymongo': '3.2.1',
-                       'six': '1.7.3'}
+                       'six': '1.7.3',
+                       'requests': '2.16.2'}
 
     def test_rubygems_solver(self, rubygems):
         solver = get_ecosystem_solver(rubygems)


### PR DESCRIPTION
Even the PEP 440 says that its use is heavily discouraged.

Related to https://github.com/fabric8-analytics/fabric8-analytics-server/issues/104