### PR TITLE
Handle cloning of non-existent git repos

### DIFF
--- a/f8a_worker/process.py
+++ b/f8a_worker/process.py
@@ -44,6 +44,9 @@ class Git(object):
             TimedCommand.get_command_output(["git", "config", "--global", "user.name", user_name])
         if not TimedCommand.get_command_output(["git", "config", "--get", "user.email"]):
             TimedCommand.get_command_output(["git", "config", "--global", "user.email", user_email])
+        # Use 'true' as external program to ask for credentials, i.e. don't ask
+        # Better would be GIT_TERMINAL_PROMPT=0, but that requires git >= 2.3
+        TimedCommand.get_command_output(["git", "config", "--global", "core.askpass", "/usr/bin/true"])
 
     @classmethod
     def clone(cls, url, path, depth=None, branch=None):

--- a/f8a_worker/utils.py
+++ b/f8a_worker/utils.py
@@ -151,7 +151,8 @@ def tempdir():
     try:
         yield dirpath
     finally:
-        shutil.rmtree(dirpath)
+        if os_path.isdir(dirpath):
+            shutil.rmtree(dirpath)
 
 
 @contextmanager

--- a/f8a_worker/workers/githuber.py
+++ b/f8a_worker/workers/githuber.py
@@ -118,8 +118,8 @@ class GithubTask(BaseTask):
         gh = github.Github(login_or_token=token)
         try:
             repo = gh.get_repo(full_name_or_id=self._repo_name, lazy=False)
-        except github.GithubException as e:
-            self.log.exception(str(e))
+        except github.GithubException:
+            self.log.error("Failed to get repo %s" % self._repo_name)
             result_data['status'] = 'error'
             return result_data
 


### PR DESCRIPTION
Fixes #283 

The error/exception is still logged, but

- we don't wait for the `git clone` to timeout due to interactively asking for credentials
- the error message explicitly says what happened