### PR TITLE
[openshift/template.yaml] increase memory limit to 1.5GiB

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -242,7 +242,7 @@ objects:
               memory: "512Mi"
               cpu: "300m"
             limits:
-              memory: "1200Mi"
+              memory: "1536Mi"
               cpu: "500m"
         restartPolicy: Always
     test: false


### PR DESCRIPTION
according to docker stats, the container needs around 1.3-1.4GiB
when scancode toolkit is scanning some maven artifacts

Fixes #326