### PR TITLE
ossindex 'bug'? work-around

### DIFF
--- a/f8a_worker/workers/cvedbsync.py
+++ b/f8a_worker/workers/cvedbsync.py
@@ -67,7 +67,7 @@ class CVEDBSyncTask(BaseTask):
         msg = "Components to be {prefix}scanned for vulnerabilities: {components}".\
             format(prefix="re-" if only_already_scanned else "",
                    components=to_scan)
-        self.log.debug(msg)
+        self.log.info(msg)
         return to_scan
 
     def execute(self, arguments):


### PR DESCRIPTION
Example:
https://ossindex.net/v2.0/vulnerability/pm/maven/fromtill/1900000000000/-1
should return no results because the timestamp is way in future,
but for some reason there's always at least one entry.

Remove it - if its 'updated' time is lower than the specified 'from_time'.