### PR TITLE
collect github-statistics also during manifest data collection

### DIFF
--- a/f8a_worker/dispatcher/flows/githubManifestMetadataFlow.yml
+++ b/f8a_worker/dispatcher/flows/githubManifestMetadataFlow.yml
@@ -33,6 +33,6 @@
                    key: 'recursive_limit'
                    value: 0
         - from: 'dependency_snapshot'
-          to:    'github_manifest_details'	
-        - from:    'github_manifest_details'
+          to: 'github_details'
+        - from: 'github_details'
           to: 'GitHubManifestMetadataResultCollector'

--- a/f8a_worker/dispatcher/flows/githubManifestMetadataFlow.yml
+++ b/f8a_worker/dispatcher/flows/githubManifestMetadataFlow.yml
@@ -33,4 +33,6 @@
                    key: 'recursive_limit'
                    value: 0
         - from: 'dependency_snapshot'
+	  to:    'github_manifest_details'	
+	- from:    'github_manifest_details'
           to: 'GitHubManifestMetadataResultCollector'

--- a/f8a_worker/dispatcher/flows/githubManifestMetadataFlow.yml
+++ b/f8a_worker/dispatcher/flows/githubManifestMetadataFlow.yml
@@ -33,6 +33,6 @@
                    key: 'recursive_limit'
                    value: 0
         - from: 'dependency_snapshot'
-	  to:    'github_manifest_details'	
-	- from:    'github_manifest_details'
+          to:    'github_manifest_details'	
+        - from:    'github_manifest_details'
           to: 'GitHubManifestMetadataResultCollector'

--- a/f8a_worker/dispatcher/nodes.yml
+++ b/f8a_worker/dispatcher/nodes.yml
@@ -284,12 +284,6 @@
       max_retry: 0
       storage: 'BayesianPostgres'
       queue: '{DEPLOYMENT_PREFIX}_{WORKER_ADMINISTRATION_REGION}_GitHubManifestMetadataGithubTask_v0'
-    - name: 'github_manifest_details'
-      classname: 'GithubStats'
-      import: 'f8a_worker.workers'
-      max_retry: 0
-      storage: 'BayesianPostgres'
-      queue: '{DEPLOYMENT_PREFIX}_{WORKER_ADMINISTRATION_REGION}_GitHubManifestMetadataGithubTask_v0'
     - name: 'git_stats'
       classname: 'GitStats'
       import: 'f8a_worker.workers'

--- a/f8a_worker/dispatcher/nodes.yml
+++ b/f8a_worker/dispatcher/nodes.yml
@@ -284,6 +284,12 @@
       max_retry: 0
       storage: 'BayesianPostgres'
       queue: '{DEPLOYMENT_PREFIX}_{WORKER_ADMINISTRATION_REGION}_GitHubManifestMetadataGithubTask_v0'
+    - name: 'github_manifest_details'
+      classname: 'GithubStats'
+      import: 'f8a_worker.workers'
+      max_retry: 0
+      storage: 'BayesianPostgres'
+      queue: '{DEPLOYMENT_PREFIX}_{WORKER_ADMINISTRATION_REGION}_GitHubManifestMetadataGithubTask_v0'
     - name: 'git_stats'
       classname: 'GitStats'
       import: 'f8a_worker.workers'

--- a/f8a_worker/workers/__init__.py
+++ b/f8a_worker/workers/__init__.py
@@ -35,3 +35,4 @@ from f8a_worker.workers.sentiment_scorer import RecoPkgSentimentScoringTask
 from f8a_worker.workers.keywords_tagging import KeywordsTaggingTask
 from f8a_worker.workers.repository_description import RepositoryDescCollectorTask
 from f8a_worker.workers.keywords_summary import KeywordsSummaryTask
+from f8a_worker.workers.githubstats import GithubStats

--- a/f8a_worker/workers/githuber.py
+++ b/f8a_worker/workers/githuber.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from f8a_worker.schemas import SchemaRef
 from f8a_worker.base import BaseTask
 from f8a_worker.utils import parse_gh_repo
+from f8a_worker.worker.githubstas import GithubStats
 
 REPO_PROPS = ('forks_count', 'subscribers_count',  'stargazers_count', 'open_issues_count')
 
@@ -138,6 +139,8 @@ class GithubTask(BaseTask):
                                          'weekly': last_year_commits}}
         issues.update(commits)
         result_data['details'] = issues
+        github_stats = GithubStats.execute(arguments)
+        result_data["github_stats"] = github_stats
         return result_data
 
 

--- a/f8a_worker/workers/githubstats.py
+++ b/f8a_worker/workers/githubstats.py
@@ -1,0 +1,55 @@
+from bs4 import BeautifulSoup
+import requests
+import logging
+from f8a_worker.base import BaseTask
+
+logger = logging.getLogger(__name__)
+
+class GithubStats(BaseTask):
+    """ Collects statistics by parsing Github Page """
+    _analysis_name = "github_manifest_details"
+
+    @classmethod
+    def _get_page(cls, repo_name):
+        github_url = 'https://github.com/'
+        url = github_url + "/" + repo_name
+        raw_data = requests.get(url)
+        if raw_data:
+            soup = BeautifulSoup(raw_data.text, "html.parser")
+            return soup
+        else:
+            logger.info("Could not fetch the page for repo_name:"% repo_name)
+
+    @classmethod
+    def _get_stargazers(cls, soup, repo_name):
+        stars =  soup.find(attrs={"href": repo_name + "/" + "stargazers"})
+        return (stars.text).strip() if stars is not None else 0
+
+    @classmethod
+    def _get_watchers(cls, soup, repo_name):
+        watches =soup.find(attrs={"href": repo_name + "/" + "watchers"})
+        return (watches.text).strip() if watches is not None else 0
+
+    @classmethod
+    def _get_fork_count(cls, soup, repo_name):
+        forks = soup.find(attrs={"href": repo_name + "/" + "network"})
+        return (forks.text).strip() if forks is not None else 0
+
+    @classmethod
+    def execute(cls, arguments):
+        repo_name_passed = arguments.get('repo_name')
+        repo_name = "/" + repo_name_passed
+        ecosystem = arguments.get("ecosystem")
+        soup = cls._get_page(repo_name)
+        if soup is not None:
+            github_stats = {
+                "stars": cls._get_stargazers(soup, repo_name),
+                "forks": cls._get_fork_count(soup, repo_name),
+                "watches": cls._get_watchers(soup, repo_name),
+                "repo_name": repo_name_passed,
+                "ecosystem": ecosystem
+            }
+            return github_stats
+        else:
+            logger.info("No Github Statistics is found for repo_name: %s" %repo_name_passed)
+        return


### PR DESCRIPTION
Task item for https://github.com/openshiftio/openshift.io/issues/983.
Here, the objective is: when we collect manifest data for most github stared repos., at the sametime we also need to collect watchers count, fork count and star count for the same repos. 
