### PR TITLE
License filter and detailed output from license service

### DIFF
--- a/f8a_worker/workers/recommender.py
+++ b/f8a_worker/workers/recommender.py
@@ -11,6 +11,7 @@ from f8a_worker.graphutils import (GREMLIN_SERVER_URL_REST, create_package_dict,
                                    select_latest_version)
 from f8a_worker.base import BaseTask
 from f8a_worker.utils import get_session_retry
+from f8a_worker.workers.stackaggregator_v2 import perform_license_analysis
 
 
 danger_word_list = ["drop\(\)", "V\(\)", "count\(\)"]
@@ -639,6 +640,39 @@ class RecommendationTask(BaseTask):
             similarity_list.append(s_stack)
         return similarity_list
 
+def apply_license_filter(epv_list):
+    dependencies = []
+    licenses = []
+    license_score_list = []
+    for epv in epv_list:
+        name = epv.get('pkg', {}).get('name', [''])[0]
+        version = epv.get('ver', {}).get('version', [''])[0]
+        licenses = epv.get('ver', {}).get('version', {}).get('licenses', [])
+
+        license_scoring_input = {
+            'package': name,
+            'version': version,
+            'licenses': licenses
+        }
+        license_score_list.append(license_scoring_input)
+
+    # Call License Scoring to Get Stack License
+    license_analysis, dependencies = perform_license_analysis(license_score_list, dependencies)
+    conflicting_companions = []
+    if license_analysis['status'] == 'StackLicenseConflict':
+        conflict_packages = license_analysis.get('conflict_packages', {})
+        for conflict in conflict_packages:
+            for pkg in conflict.keys():
+                conflicting_companions.append(pkg)
+    conflicting_companions = list(set(conflicting_companions))
+
+    for epv in epv_list:
+        name = epv.get('pkg', {}).get('name', [''])[0]
+        if name in conflicting_companions:
+            epv_list.remove(epv)
+
+    return epv_list, conflicting_companions
+
 
 class RecommendationV2Task(BaseTask):
     _analysis_name = 'recommendation_v2'
@@ -745,11 +779,16 @@ class RecommendationV2Task(BaseTask):
                                  .format(parguments.get('external_request_id', ''),
                                          set(companion_packages).difference(set(filtered_list))))
 
-                    # Get Topics Added to Filtered Versions
-                    topics_comp_packages_graph = GraphDB().get_topics_for_comp(
-                        filtered_comp_packages_graph,
-                        pgm_result['companion_packages'])
+                    # Apply License Filters
+                    lic_filtered_companions, lic_filtered_list = apply_license_filter(filtered_comp_packages_graph, input_stack)
 
+                    _logger.info("Companion Packages further filtered (based on licenses) for external_request_id {} {}"
+                                 .format(parguments.get('external_request_id', ''),
+                                         set(companion_packages).difference(set(lic_filtered_list))))
+
+                    # Get Topics Added to Filtered Versions
+                    topics_comp_packages_graph = GraphDB().get_topics_for_comp(lic_filtered_companions,
+                                                                               pgm_result['companion_packages'])
                     # Create Companion Block
                     comp_packages = create_package_dict(topics_comp_packages_graph)
                     recommendation['companion'] = comp_packages

--- a/f8a_worker/workers/recommender.py
+++ b/f8a_worker/workers/recommender.py
@@ -13,8 +13,7 @@ from f8a_worker.graphutils import (GREMLIN_SERVER_URL_REST, create_package_dict,
                                    select_latest_version, LICENSE_SCORING_URL_REST)
 from f8a_worker.base import BaseTask
 from f8a_worker.utils import get_session_retry
-from f8a_worker.workers.stackaggregator_v2 import perform_license_analysis, get_dependency_data, aggregate_stack_data, \
-    extract_user_stack_package_licenses
+from f8a_worker.workers.stackaggregator_v2 import extract_user_stack_package_licenses
 
 
 danger_word_list = ["drop\(\)", "V\(\)", "count\(\)"]
@@ -665,27 +664,19 @@ def invoke_license_analysis_service(user_stack_packages, alternate_packages, com
 def apply_license_filter(user_stack_components, epv_list_alt, epv_list_com):
     license_score_list_alt = []
     for epv in epv_list_alt:
-        name = epv.get('pkg', {}).get('name', [''])[0]
-        version = epv.get('ver', {}).get('version', [''])[0]
-        licenses = epv.get('ver', {}).get('version', {}).get('licenses', [])
-
         license_scoring_input = {
-            'package': name,
-            'version': version,
-            'licenses': licenses
+            'package': epv.get('pkg', {}).get('name', [''])[0],
+            'version': epv.get('ver', {}).get('version', [''])[0],
+            'licenses': epv.get('ver', {}).get('version', {}).get('licenses', [])
         }
         license_score_list_alt.append(license_scoring_input)
 
     license_score_list_com = []
     for epv in epv_list_com:
-        name = epv.get('pkg', {}).get('name', [''])[0]
-        version = epv.get('ver', {}).get('version', [''])[0]
-        licenses = epv.get('ver', {}).get('version', {}).get('licenses', [])
-
         license_scoring_input = {
-            'package': name,
-            'version': version,
-            'licenses': licenses
+            'package': epv.get('pkg', {}).get('name', [''])[0],
+            'version': epv.get('ver', {}).get('version', [''])[0],
+            'licenses': epv.get('ver', {}).get('version', {}).get('licenses', [])
         }
         license_score_list_com.append(license_scoring_input)
 
@@ -694,8 +685,7 @@ def apply_license_filter(user_stack_components, epv_list_alt, epv_list_com):
                                                 license_score_list_alt,
                                                 license_score_list_com)
 
-    conflict_packages_alt = []
-    conflict_packages_com = []
+    conflict_packages_alt = conflict_packages_com = []
     if la_output['status'] == 'Successful' and la_output['license_filter'] is not None:
         license_filter = la_output.get('license_filter', {})
         conflict_packages_alt = license_filter.get('alternate_packages', {}).get('conflict_packages', [])

--- a/f8a_worker/workers/recommender.py
+++ b/f8a_worker/workers/recommender.py
@@ -657,9 +657,8 @@ def invoke_license_analysis_service(user_stack_packages, alternate_packages, com
         lic_response = get_session_retry().post(license_url, data=json.dumps(payload))
         lic_response.raise_for_status()  # raise exception for bad http-status codes
         json_response = lic_response.json()
-    except requests.exceptions.RequestException as e:
-        msg = "Unexpected error happened while invoking license analysis!\n{}".format(e)
-        _logger.error(msg)
+    except requests.exceptions.RequestException:
+        _logger.exception("Unexpected error happened while invoking license analysis!")
         pass
 
     return json_response
@@ -698,14 +697,14 @@ def apply_license_filter(user_stack_components, epv_list_alt, epv_list_com):
                                               .get('conflict_packages', [])
 
     list_pkg_names_alt = []
-    for epv in epv_list_alt:
+    for epv in epv_list_alt[:]:
         name = epv.get('pkg', {}).get('name', [''])[0]
         if name in conflict_packages_alt:
             list_pkg_names_alt.append(name)
             epv_list_alt.remove(epv)
 
     list_pkg_names_com = []
-    for epv in epv_list_com:
+    for epv in epv_list_com[:]:
         name = epv.get('pkg', {}).get('name', [''])[0]
         if name in conflict_packages_com:
             list_pkg_names_com.append(name)

--- a/f8a_worker/workers/stackaggregator_v2.py
+++ b/f8a_worker/workers/stackaggregator_v2.py
@@ -230,10 +230,8 @@ def perform_license_analysis(license_score_list, dependencies):
         lic_response = get_session_retry().post(license_url, data=json.dumps(payload))
         lic_response.raise_for_status()  # raise exception for bad http-status codes
         resp = lic_response.json()
-    except requests.exceptions.RequestException as e:
-        msg = "Unexpected error happened while invoking license analysis!\n{}".format(e)
-        _logger.error(msg)
-
+    except requests.exceptions.RequestException:
+        _logger.exception("Unexpected error happened while invoking license analysis!")
         flag_stack_license_exception = True
         pass
 
@@ -358,8 +356,8 @@ def get_dependency_data(resolved, ecosystem):
             else:
                 _logger.error("Failed retrieving dependency data.")
                 continue
-        except Exception as e:
-            _logger.error("Error retrieving dependency data!\n {}".format(e))
+        except Exception:
+            _logger.exception("Error retrieving dependency data!")
             continue
 
     return {"result": result}

--- a/f8a_worker/workers/stackaggregator_v2.py
+++ b/f8a_worker/workers/stackaggregator_v2.py
@@ -99,6 +99,18 @@ def extract_component_details(component):
 
 
 def _extract_conflict_packages(license_service_output):
+    """
+    This helper function extracts conflict licenses from the given output
+    of license analysis REST service.
+
+    It returns a list of pairs of packages whose licenses are in conflict.
+    Note that this information is only available when each component license
+    was identified ( i.e. no unknown and no component level conflict ) and
+    there was a stack level license conflict.
+
+    :param license_service_output: output of license analysis REST service
+    :return: list of pairs of packages whose licenses are in conflict
+    """
     license_conflict_packages = []
     if not license_service_output:
         return license_conflict_packages
@@ -119,9 +131,28 @@ def _extract_conflict_packages(license_service_output):
 
 
 def _extract_unknown_licenses(license_service_output):
-    unknown_licenses = []
+    """
+    This helper function extracts unknown licenses information from the given
+    output of license analysis REST service.
+
+    At the moment, there are two types of unknowns:
+
+    a. really unknown licenses: those licenses, which are not understood by our system.
+    b. component level conflicting licenses: if a component has multiple licenses
+        associated then license analysis service tries to identify a representative
+        license for this component. If some licenses are in conflict, then its
+        representative license cannot be identified and this is another type of
+        'unknown' !
+
+    This function returns both types of unknown licenses.
+
+    :param license_service_output: output of license analysis REST service
+    :return: list of packages with unknown licenses and/or conflicting licenses
+    """
+    really_unknown_licenses = []
+    lic_conflict_licenses = []
     if not license_service_output:
-        return unknown_licenses
+        return really_unknown_licenses
 
     if license_service_output.get('status', '') == 'Unknown':
         list_components = license_service_output.get('packages', [])
@@ -131,15 +162,46 @@ def _extract_unknown_licenses(license_service_output):
                 pkg = comp.get('package', 'Unknown')
                 comp_unknown_licenses = license_analysis.get('unknown_licenses', [])
                 for lic in comp_unknown_licenses:
-                    unknown_licenses.append({
+                    really_unknown_licenses.append({
                         'package': pkg,
                         'license': lic
                     })
 
-    return unknown_licenses
+    if license_service_output.get('status', '') == 'ComponentLicenseConflict':
+        list_components = license_service_output.get('packages', [])
+        for comp in list_components:
+            license_analysis = comp.get('license_analysis', {})
+            if license_analysis.get('status', '') == 'Conflict':
+                pkg = comp.get('package', 'Unknown')
+                d = {
+                    "package": pkg
+                }
+                comp_conflict_licenses = license_analysis.get('conflict_licenses', [])
+                list_conflicting_pairs = []
+                for pair in comp_conflict_licenses:
+                    assert (len(pair) == 2)
+                    list_conflicting_pairs.append({
+                        'license1': pair[0],
+                        'license2': pair[1]
+                    })
+                d['conflict_licenses'] = list_conflicting_pairs
+                lic_conflict_licenses.append(d)
+
+    output = {
+        'really_unknown': really_unknown_licenses,
+        'component_conflict': lic_conflict_licenses
+    }
+    return output
 
 
 def _extract_license_outliers(license_service_output):
+    """
+    This helper function extracts license outliers from the given output of
+    license analysis REST service.
+
+    :param license_service_output: output of license analysis REST service
+    :return: list of license outlier packages
+    """
     outliers = []
     if not license_service_output:
         return outliers

--- a/f8a_worker/workers/stackaggregator_v2.py
+++ b/f8a_worker/workers/stackaggregator_v2.py
@@ -9,11 +9,14 @@ Output: TBD
 import json
 import datetime
 
+import logging
+
 from f8a_worker.base import BaseTask
 from f8a_worker.graphutils import (GREMLIN_SERVER_URL_REST, LICENSE_SCORING_URL_REST,
                                    select_latest_version)
 from f8a_worker.utils import get_session_retry
 
+_logger = logging.getLogger(__name__)
 
 def extract_component_details(component):
     github_details = {
@@ -137,6 +140,22 @@ def perform_license_analysis(license_score_list, dependencies):
     }
     return output, dependencies
 
+def extract_user_stack_package_licenses(resolved, ecosystem):
+    user_stack = get_dependency_data(resolved, ecosystem)
+    list_package_licenses = []
+    if user_stack is not None:
+        for component in user_stack.get('result', []):
+            data = component.get("data", None)
+            if data:
+                component_data = extract_component_details(data[0])
+                license_scoring_input = {
+                    'package': component_data['name'],
+                    'version': component_data['version'],
+                    'licenses': component_data['licenses']
+                }
+                list_package_licenses.append(license_scoring_input)
+
+    return list_package_licenses
 
 def aggregate_stack_data(stack, manifest_file, ecosystem, deps, manifest_file_path):
     dependencies = []
@@ -181,45 +200,38 @@ def aggregate_stack_data(stack, manifest_file, ecosystem, deps, manifest_file_pa
     }
     return data
 
+def get_dependency_data(resolved, ecosystem):
+    result = []
+    for elem in resolved:
+        qstring = "g.V().has('pecosystem','"+ecosystem+"').has('pname','"+elem["package"]+"')." \
+                  "has('version','"+elem["version"]+"')." \
+                  "as('version').in('has_version').as('package').select('version','package').by(valueMap());"
+        payload = {'gremlin': qstring}
+
+        try:
+            graph_req = get_session_retry().post(GREMLIN_SERVER_URL_REST, data=json.dumps(payload))
+
+            if graph_req.status_code == 200:
+                graph_resp = graph_req.json()
+                if 'result' not in graph_resp:
+                    continue
+                if len(graph_resp['result']['data']) == 0:
+                    continue
+
+                result.append(graph_resp["result"])
+            else:
+                _logger.error("Failed retrieving dependency data.")
+                continue
+        except:
+            _logger.error("Error retrieving dependency data.")
+            continue
+
+    return {"result": result}
+
 
 class StackAggregatorV2Task(BaseTask):
     """ Aggregates stack data from components """
     _analysis_name = 'stack_aggregator_v2'
-
-    def _get_dependency_data(self, resolved, ecosystem):
-        # Hardcoded ecosystem
-        result = []
-        for elem in resolved:
-            if elem["package"] is None or elem["version"] is None:
-                self.log.warning("Either component name or component version is missing")
-                continue
-
-            qstring = "g.V().has('pecosystem','" + ecosystem + "').has('pname','" + \
-                      elem["package"] + "').has('version','" + elem["version"] + "')." \
-                      "as('version').in('has_version').as('package').select('version','package')." \
-                      "by(valueMap());"
-            payload = {'gremlin': qstring}
-
-            try:
-                graph_req = get_session_retry().post(GREMLIN_SERVER_URL_REST,
-                                                     data=json.dumps(payload))
-
-                if graph_req.status_code == 200:
-                    graph_resp = graph_req.json()
-                    if 'result' not in graph_resp:
-                        continue
-                    if len(graph_resp['result']['data']) == 0:
-                        continue
-
-                    result.append(graph_resp["result"])
-                else:
-                    self.log.error("Failed retrieving dependency data.")
-                    continue
-            except Exception:
-                self.log.error("Error retrieving dependency data.")
-                continue
-
-        return {"result": result}
 
     def execute(self, arguments=None):
         finished = []
@@ -232,7 +244,7 @@ class StackAggregatorV2Task(BaseTask):
             manifest = result['details'][0]['manifest_file']
             manifest_file_path = result['details'][0]['manifest_file_path']
 
-            finished = self._get_dependency_data(resolved, ecosystem)
+            finished = get_dependency_data(resolved, ecosystem)
             if finished is not None:
                 stack_data.append(aggregate_stack_data(finished, manifest, ecosystem.lower(),
                                   resolved, manifest_file_path))


### PR DESCRIPTION
Hi @miteshvp @pkajaba ,

Can you please review the license related changes in the worker ? There are mainly two changes:

1. Stack Aggregator v2 ( stackaggregator_v2.py ) now extracts details like unknown licenses, conflicting licenses, license outlier packages, etc. from the license analysis REST service.

2. Recommender ( recommender.py ) now filters PGM recommendations based on license i.e. we avoid recommending any package(s) that might result in conflict later if user chooses that package.

Thanks,
Harjinder
