### PR TITLE
Always resolve POMs in mercator

### DIFF
--- a/f8a_worker/workers/graphaggregator.py
+++ b/f8a_worker/workers/graphaggregator.py
@@ -61,7 +61,7 @@ class GraphAggregatorTask(BaseTask):
                 # Create instance manually since stack analysis is not handled by dispatcher
                 subtask = MercatorTask.create_test_instance(task_name=self.task_name)
                 arguments['ecosystem'] = manifest['ecosystem']
-                out = subtask.run_mercator(arguments, temp_path, resolve_poms=False)
+                out = subtask.run_mercator(arguments, temp_path)
 
             if not out["details"]:
                 raise FatalTaskError("No metadata found processing manifest file '{}'"


### PR DESCRIPTION
Restore the previous behavior when [[1]](https://github.com/openshiftio/openshift.io/issues/1063) is done/in progress.

