### PR TITLE
Fix license analysis and filter

### DIFF
--- a/f8a_worker/workers/recommender.py
+++ b/f8a_worker/workers/recommender.py
@@ -670,7 +670,7 @@ def apply_license_filter(user_stack_components, epv_list_alt, epv_list_com):
         license_scoring_input = {
             'package': epv.get('pkg', {}).get('name', [''])[0],
             'version': epv.get('ver', {}).get('version', [''])[0],
-            'licenses': epv.get('ver', {}).get('version', {}).get('licenses', [])
+            'licenses': epv.get('ver', {}).get('licenses', [])
         }
         license_score_list_alt.append(license_scoring_input)
 
@@ -679,7 +679,7 @@ def apply_license_filter(user_stack_components, epv_list_alt, epv_list_com):
         license_scoring_input = {
             'package': epv.get('pkg', {}).get('name', [''])[0],
             'version': epv.get('ver', {}).get('version', [''])[0],
-            'licenses': epv.get('ver', {}).get('version', {}).get('licenses', [])
+            'licenses': epv.get('ver', {}).get('licenses', [])
         }
         license_score_list_com.append(license_scoring_input)
 
@@ -716,6 +716,7 @@ def apply_license_filter(user_stack_components, epv_list_alt, epv_list_com):
         'filtered_comp_packages_graph': epv_list_com,
         'filtered_list_pkg_names_com': list_pkg_names_com
     }
+    _logger.info("License Filter output: {}".format(json.dumps(output)))
 
     return output
 

--- a/f8a_worker/workers/stackaggregator_v2.py
+++ b/f8a_worker/workers/stackaggregator_v2.py
@@ -336,10 +336,10 @@ def get_dependency_data(resolved, ecosystem):
             continue
 
         qstring = \
-            "g.V().has('pecosystem', '{}').has('pname', '{}').has('version', '{}')" + \
+            "g.V().has('pecosystem', '{}').has('pname', '{}').has('version', '{}')" \
+            .format(ecosystem, elem["package"], elem["version"]) + \
             ".as('version').in('has_version').as('package')" + \
-            ".select('version','package').by(valueMap());"\
-            .format(ecosystem, elem["package"], elem["version"])
+            ".select('version','package').by(valueMap());"
         payload = {'gremlin': qstring}
 
         try:


### PR DESCRIPTION
Hi @miteshvp ,

Can you please review and merge the fix for license analysis and filter issue that we encountered on stage today ?

There are two fixes:
1) In recommender.py, I fixed how we access 'licenses' information for a 'version' vertex of graph.
2) In stackaggregator_v2.py, I fixed the string formatting issue.

Thanks,
Harjinder