### PR TITLE
[TestFetcher] Remove System.Data.SQLite

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -242,10 +242,7 @@ class TestFetcher(object):
         ('Microsoft.AspNet.Mvc',
          {'5.0.0', '5.2.0', '5.2.3'}),
         ('NUnit',
-         {'2.6.4', '3.0.0', '3.7.1'}),
-        # Only one not sem-ver-compliant version
-        ('System.Data.SQLite',
-         {'1.0.105.2'})
+         {'2.6.4', '3.0.0', '3.7.1'})
     ])
     def test_nuget_fetcher(self, nuget, package, expected):
         f = NugetReleasesFetcher(nuget)


### PR DESCRIPTION
Previously there was only one not sem-ver compliant version in
https://www.nuget.org/packages/System.Data.SQLite
Now they've replaced! 1.0.105.2 with 1.0.106 in version history.
Remove the test completely since 1.0.106 is sem-ver compliant.