### PR TITLE
use declared_licenses instead of licenses (detected)

### DIFF
--- a/f8a_worker/graphutils.py
+++ b/f8a_worker/graphutils.py
@@ -137,7 +137,7 @@ def extract_component_details(component):
             "vulnerabilities": cves
         }
 
-    licenses = component.get("version", {}).get("licenses", [])
+    licenses = component.get("version", {}).get("declared_licenses", [])
     name = component.get("version", {}).get("pname", [""])[0]
     version = component.get("version", {}).get("version", [""])[0]
     ecosystem = component.get("version", {}).get("pecosystem", [""])[0]
@@ -213,7 +213,7 @@ def create_package_dict(graph_results, alt_dict=None):
                 'ecosystem': ecosystem,
                 'name': name,
                 'version': version,
-                'licenses': epv['ver'].get('licenses', []),
+                'licenses': epv['ver'].get('declared_licenses', []),
                 'latest_version': select_latest_version(
                     epv['pkg'].get('libio_latest_version', [''])[0],
                     epv['pkg'].get('latest_version', [''])[0]),

--- a/f8a_worker/workers/recommender.py
+++ b/f8a_worker/workers/recommender.py
@@ -673,7 +673,7 @@ def apply_license_filter(user_stack_components, epv_list_alt, epv_list_com):
         license_scoring_input = {
             'package': epv.get('pkg', {}).get('name', [''])[0],
             'version': epv.get('ver', {}).get('version', [''])[0],
-            'licenses': epv.get('ver', {}).get('licenses', [])
+            'licenses': epv.get('ver', {}).get('declared_licenses', [])
         }
         license_score_list_alt.append(license_scoring_input)
 
@@ -682,7 +682,7 @@ def apply_license_filter(user_stack_components, epv_list_alt, epv_list_com):
         license_scoring_input = {
             'package': epv.get('pkg', {}).get('name', [''])[0],
             'version': epv.get('ver', {}).get('version', [''])[0],
-            'licenses': epv.get('ver', {}).get('licenses', [])
+            'licenses': epv.get('ver', {}).get('declared_licenses', [])
         }
         license_score_list_com.append(license_scoring_input)
 

--- a/f8a_worker/workers/stackaggregator_v2.py
+++ b/f8a_worker/workers/stackaggregator_v2.py
@@ -78,7 +78,7 @@ def extract_component_details(component):
         }
         cves.append(component_cve)
 
-    licenses = component.get("version", {}).get("licenses", [])
+    licenses = component.get("version", {}).get("declared_licenses", [])
     name = component.get("version", {}).get("pname", [""])[0]
     version = component.get("version", {}).get("version", [""])[0]
     ecosystem = component.get("version", {}).get("pecosystem", [""])[0]


### PR DESCRIPTION
Currently we show detected `licenses` on OSIO dashboard and license scoring also uses detected licenses to calculate stack license. It should be modified to use `declared_licenses`.