### PR TITLE
revert 'Reuse WORKER_RUN_DB_MIGRATIONS to configure SQS queues only from one pod.'

### DIFF
--- a/hack/queue_conf.py
+++ b/hack/queue_conf.py
@@ -61,10 +61,6 @@ def set_queue_attributes(queue_names):
             )
             _logger.debug("Remote responded with %r after setting queue tag for %r",
                           response, queue_name)
-            # Tagging API actions are limited to 5 TPS (Transactions Per Second) per AWS account.
-            # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/
-            # SQSDeveloperGuide/limits-queues.html
-            sleep(1 / 5)
 
     _logger.info("Queue attributes were adjusted for all %d queues" % len(queue_names))
 

--- a/hack/worker-pre-hook.sh
+++ b/hack/worker-pre-hook.sh
@@ -3,14 +3,6 @@
 
 set -e
 
-# We need *only one* worker pod to run db migrations and configure SQS queues.
-# For now we use the same WORKER_RUN_DB_MIGRATIONS env variable for both,
-# because a pod would either do both operations or none.
-if [ -z "${WORKER_RUN_DB_MIGRATIONS}" ]; then
-    echo "WORKER_RUN_DB_MIGRATIONS was not set - this worker will neither run database migrations nor configure queue attributes"
-    exit 0
-fi
-
 /alembic/run-db-migrations.sh
 
 # Fill in $WORKER_QUEUES


### PR DESCRIPTION
When testing https://github.com/fabric8-analytics/fabric8-analytics-common/pull/446 I realized that only '_api_' queues are configured during deployment.

This PR reverts c671b4dfd748, which I think causes the problem.

The `worker-pre-hook.sh` change had been added due to the `sleep(1/5)` in `queue_conf.py`, but we actually don't need either, since I've tested that SQS is able to properly handle many tagging requests per second - I created a script which tries to tag queues in parallel processes without any sleeping and all queues were tagged correctly.