### PR TITLE
Reflect the changes on GitHub side

### DIFF
--- a/tests/workers/test_githuber.py
+++ b/tests/workers/test_githuber.py
@@ -28,7 +28,7 @@ class TestGithuber(object):
         assert results['details']['forks_count'] > 0
         assert set(results['details']['last_year_commits'].keys()) == {'sum', 'weekly'}
         assert results['details']['license'] == {'key': 'bsd-3-clause',
-                                                 'name': 'BSD 3-clause "New" or "Revised" License',
+                                                 'name': 'BSD 3-Clause "New" or "Revised" License',
                                                  'spdx_id': 'BSD-3-Clause',
                                                  'url':
                                                      'https://api.github.com/licenses/bsd-3-clause'}


### PR DESCRIPTION
The following API call:
```
https://api.github.com/licenses/bsd-3-clause
```

returns:

```
name | "BSD 3-Clause \"New\" or \"Revised\" License"
```

ie "Clause" has uppercase "C"


