### PR TITLE
Unify error handling

### DIFF
--- a/f8a_worker/workers/csmock_worker.py
+++ b/f8a_worker/workers/csmock_worker.py
@@ -11,6 +11,7 @@ Kamil's presentation at Flock 2014: https://kdudka.fedorapeople.org/static-analy
 import json
 import os
 import sys
+from selinon import FatalTaskError
 import subprocess
 
 from f8a_worker.base import BaseTask
@@ -91,8 +92,9 @@ class CsmockTask(BaseTask):
             result_data['status'] = 'success'
             result_data['details'] = analysis_result
         except Exception as ex:
-            self.log.error("static analysis was not successful: %r", ex)
-            result_data['status'] = 'error'
+            msg = "static analysis was not successful: %r" % ex
+            self.log.error(msg)
+            raise FatalTaskError(msg) from ex
 
         return result_data
 

--- a/f8a_worker/workers/githuber.py
+++ b/f8a_worker/workers/githuber.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 
 import requests
 from collections import OrderedDict
+from selinon import FatalTaskError
 
 from f8a_worker.base import BaseTask
 from f8a_worker.errors import F8AConfigurationException, TaskError
@@ -80,16 +81,14 @@ class GithubTask(BaseTask):
             self._headers.update(header)
         except F8AConfigurationException as e:
             self.log.error(e)
-            result_data['status'] = 'error'
-            return result_data
+            raise FatalTaskError from e
 
         repo_url = urljoin(self.configuration.GITHUB_API + "repos/", self._repo_name)
         try:
             repo = get_response(repo_url, self._headers)
         except TaskError as e:
-            self.log.debug(e)
-            result_data['status'] = 'error'
-            return result_data
+            self.log.error(e)
+            raise FatalTaskError from e
 
         result_data['status'] = 'success'
 

--- a/f8a_worker/workers/mercator.py
+++ b/f8a_worker/workers/mercator.py
@@ -24,6 +24,7 @@ sample output:
 
 import os
 import json
+from selinon import FatalTaskError
 
 from f8a_worker.base import BaseTask
 from f8a_worker.data_normalizer import DataNormalizer
@@ -208,8 +209,8 @@ class MercatorTask(BaseTask):
                                        update_env=update_env)
         if status != 0:
             self.log.error(err)
-            result_data['status'] = 'error'
-            return result_data
+            raise FatalTaskError(err)
+
         ecosystem_object = self.storage.get_ecosystem(arguments['ecosystem'])
         if ecosystem_object.is_backed_by(EcosystemBackend.pypi):
             # TODO: attempt static setup.py parsing with mercator

--- a/f8a_worker/workers/oscryptocatcher.py
+++ b/f8a_worker/workers/oscryptocatcher.py
@@ -3,6 +3,8 @@
 Output: list of files along with crypto algorithm they contain
 """
 
+from selinon import FatalTaskError
+
 from f8a_worker.utils import TimedCommand
 from f8a_worker.base import BaseTask
 from f8a_worker.schemas import SchemaRef
@@ -37,6 +39,6 @@ class OSCryptoCatcherTask(BaseTask):
             results['summary'] = oscc['summary']
             results['status'] = 'success'
         except Exception:
-            results['status'] = 'error'
+            raise FatalTaskError('oscryptocatcher failed')
 
         return results


### PR DESCRIPTION
Let selinon handle exceptions instead of masking them into `{'status': 'error'}`.

Fixes https://github.com/openshiftio/openshift.io/issues/2150