### PR TITLE
Remove utils.tempdir and use tempfile.TemporaryDirectory instead

### DIFF
--- a/f8a_worker/data_normalizer.py
+++ b/f8a_worker/data_normalizer.py
@@ -6,14 +6,15 @@ Code to transform data from Mercator [1] into a common scheme.
 [1] https://github.com/fabric8-analytics/mercator-go
 """
 
-import sys
 import argparse
+from itertools import zip_longest
 import json
 from os import path
-from itertools import zip_longest
+import sys
+from tempfile import TemporaryDirectory
 from urllib.parse import urlparse
 
-from f8a_worker.utils import parse_gh_repo, tempdir
+from f8a_worker.utils import parse_gh_repo
 
 
 # TODO: we need to unify the output from different ecosystems
@@ -456,7 +457,7 @@ class DataNormalizer(object):
             # It's here due to circular dependencies
             from f8a_worker.workers import LicenseCheckTask  # run_scancode
             transformed['declared_licenses'] = [data['LicenseUrl']]
-            with tempdir() as tmpdir:
+            with TemporaryDirectory() as tmpdir:
                 try:
                     # Get file from 'LicenseUrl' and let LicenseCheckTask decide what license it is
                     if IndianaJones.download_file(data['LicenseUrl'], tmpdir):

--- a/f8a_worker/solver.py
+++ b/f8a_worker/solver.py
@@ -13,12 +13,12 @@ from requests import get
 from xmlrpc.client import ServerProxy
 from semantic_version import Version as semver_version
 from subprocess import check_output
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from urllib.parse import urljoin
 
 from f8a_worker.enums import EcosystemBackend
 from f8a_worker.models import Analysis, Ecosystem, Package, Version
-from f8a_worker.utils import cwd, tempdir, TimedCommand
+from f8a_worker.utils import cwd, TimedCommand
 from f8a_worker.process import Git
 
 
@@ -952,7 +952,7 @@ class MavenSolver(object):
         """
         if not to_solve:
             return {}
-        with tempdir() as tmpdir:
+        with TemporaryDirectory() as tmpdir:
             with cwd(tmpdir):
                 MavenSolver._generate_pom_xml(to_solve)
                 return MavenSolver._dependencies_from_pom_xml()

--- a/f8a_worker/storages/s3_mavenindex.py
+++ b/f8a_worker/storages/s3_mavenindex.py
@@ -1,8 +1,10 @@
-import os
 import botocore
+import os
+from tempfile import TemporaryDirectory
+
 from f8a_worker.errors import TaskError
 from f8a_worker.process import Archive
-from f8a_worker.utils import tempdir
+
 from . import AmazonS3
 
 
@@ -15,7 +17,7 @@ class S3MavenIndex(AmazonS3):
 
     def store_index(self, target_dir):
         """Zip files in target_dir/central-index dir and store to S3."""
-        with tempdir() as temp_dir:
+        with TemporaryDirectory() as temp_dir:
             central_index_dir = os.path.join(target_dir, self._INDEX_DIRNAME)
             archive_path = os.path.join(temp_dir, self._INDEX_ARCHIVE)
             try:
@@ -28,7 +30,7 @@ class S3MavenIndex(AmazonS3):
     def retrieve_index_if_exists(self, target_dir):
         """Retrieve central-index.zip from S3 and extract into target_dir/central-index."""
         if self.object_exists(self._INDEX_ARCHIVE):
-            with tempdir() as temp_dir:
+            with TemporaryDirectory() as temp_dir:
                 archive_path = os.path.join(temp_dir, self._INDEX_ARCHIVE)
                 central_index_dir = os.path.join(target_dir, self._INDEX_DIRNAME)
                 self.retrieve_file(self._INDEX_ARCHIVE, archive_path)

--- a/f8a_worker/storages/s3_vulndb.py
+++ b/f8a_worker/storages/s3_vulndb.py
@@ -1,9 +1,11 @@
 from dateutil import parser as datetime_parser
 from datetime import datetime, timezone
 import os
+from tempfile import TemporaryDirectory
+
 from f8a_worker.errors import TaskError
 from f8a_worker.process import Archive
-from f8a_worker.utils import cwd, tempdir
+from f8a_worker.utils import cwd
 from . import AmazonS3
 
 
@@ -34,7 +36,7 @@ class S3VulnDB(AmazonS3):
 
     def store_depcheck_db(self, data_dir):
         """Zip CVE DB file and store to S3."""
-        with tempdir() as archive_dir:
+        with TemporaryDirectory() as archive_dir:
             archive_path = os.path.join(archive_dir, self.DEPCHECK_DB_ARCHIVE)
             db_file_path = os.path.join(data_dir, self.DEPCHECK_DB_FILENAME)
             try:
@@ -47,7 +49,7 @@ class S3VulnDB(AmazonS3):
     def retrieve_depcheck_db_if_exists(self, data_dir):
         """Retrieve zipped CVE DB file as stored on S3 and extract."""
         if self.object_exists(self.DEPCHECK_DB_ARCHIVE):
-            with tempdir() as archive_dir:
+            with TemporaryDirectory() as archive_dir:
                 archive_path = os.path.join(archive_dir, self.DEPCHECK_DB_ARCHIVE)
                 self.retrieve_file(self.DEPCHECK_DB_ARCHIVE, archive_path)
                 Archive.extract_zip(archive_path, data_dir)
@@ -56,7 +58,7 @@ class S3VulnDB(AmazonS3):
 
     def store_victims_db(self, victims_db_dir):
         """Zip victims_db_dir/* and store to S3 as VICTIMS_DB_ARCHIVE."""
-        with tempdir() as temp_archive_dir:
+        with TemporaryDirectory() as temp_archive_dir:
             temp_archive_path = os.path.join(temp_archive_dir, self.VICTIMS_DB_ARCHIVE)
             with cwd(victims_db_dir):
                 Archive.zip_file('.', temp_archive_path)
@@ -65,7 +67,7 @@ class S3VulnDB(AmazonS3):
     def retrieve_victims_db_if_exists(self, victims_db_dir):
         """Retrieve VICTIMS_DB_ARCHIVE from S3 and extract into victims_db_dir."""
         if self.object_exists(self.VICTIMS_DB_ARCHIVE):
-            with tempdir() as temp_archive_dir:
+            with TemporaryDirectory() as temp_archive_dir:
                 temp_archive_path = os.path.join(temp_archive_dir, self.VICTIMS_DB_ARCHIVE)
                 self.retrieve_file(self.VICTIMS_DB_ARCHIVE, temp_archive_path)
                 Archive.extract_zip(temp_archive_path, victims_db_dir)

--- a/f8a_worker/utils.py
+++ b/f8a_worker/utils.py
@@ -147,22 +147,6 @@ def cwd(target):
 
 
 @contextmanager
-def tempdir():
-    """Context manager for temporary directory.
-
-    Usage:
-    with tempdir() as temp_dir:
-        use temp_dir
-    """
-    dirpath = tempfile.mkdtemp()
-    try:
-        yield dirpath
-    finally:
-        if os_path.isdir(dirpath):
-            shutil.rmtree(dirpath)
-
-
-@contextmanager
 def username():
     """Workaround for failing getpass.getuser().
 

--- a/f8a_worker/workers/cvedbsync.py
+++ b/f8a_worker/workers/cvedbsync.py
@@ -3,7 +3,6 @@
 from selinon import StoragePool
 from f8a_worker.base import BaseTask
 from f8a_worker.solver import get_ecosystem_solver, OSSIndexDependencyParser
-from f8a_worker.utils import tempdir
 from f8a_worker.workers import CVEcheckerTask
 
 

--- a/f8a_worker/workers/git_stats.py
+++ b/f8a_worker/workers/git_stats.py
@@ -4,10 +4,10 @@ import numpy as np
 from time import time
 from datetime import timedelta
 from sklearn.linear_model import LinearRegression
+from tempfile import TemporaryDirectory
 
 from f8a_worker.process import Git
 from f8a_worker.base import BaseTask
-from f8a_worker.utils import tempdir
 
 
 class GitStats(BaseTask):
@@ -24,7 +24,7 @@ class GitStats(BaseTask):
 
         :param url: url to the git repo
         """
-        with tempdir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             git = Git.clone(url, tmp_dir)
             # nice notebook to check at:
             #   http://nbviewer.jupyter.org/github/tarmstrong/code-analysis/blob/master/IPythonReviewTime.ipynb

--- a/f8a_worker/workers/graphaggregator.py
+++ b/f8a_worker/workers/graphaggregator.py
@@ -2,12 +2,12 @@ import os
 import json
 from selinon import FatalTaskError
 from sqlalchemy.exc import SQLAlchemyError
+from tempfile import TemporaryDirectory
 
 from f8a_worker.base import BaseTask
 from f8a_worker.manifests import get_manifest_descriptor_by_filename
 from f8a_worker.models import StackAnalysisRequest
 from f8a_worker.solver import get_ecosystem_solver
-from f8a_worker.utils import tempdir
 from f8a_worker.workers.mercator import MercatorTask
 
 
@@ -49,7 +49,7 @@ class GraphAggregatorTask(BaseTask):
         # If we receive a manifest file we need to save it first
         result = []
         for manifest in manifests:
-            with tempdir() as temp_path:
+            with TemporaryDirectory() as temp_path:
                 with open(os.path.join(temp_path, manifest['filename']), 'a+') as fd:
                     fd.write(manifest['content'])
 

--- a/f8a_worker/workers/mercator.py
+++ b/f8a_worker/workers/mercator.py
@@ -25,6 +25,7 @@ sample output:
 import os
 import json
 from selinon import FatalTaskError
+from tempfile import TemporaryDirectory
 
 from f8a_worker.base import BaseTask
 from f8a_worker.data_normalizer import DataNormalizer
@@ -32,7 +33,7 @@ from f8a_worker.enums import EcosystemBackend
 from f8a_worker.object_cache import ObjectCache
 from f8a_worker.process import Git
 from f8a_worker.schemas import SchemaRef
-from f8a_worker.utils import TimedCommand, tempdir
+from f8a_worker.utils import TimedCommand
 
 
 # TODO: we need to unify the output from different ecosystems
@@ -169,7 +170,7 @@ class MercatorTask(BaseTask):
     def run_mercator_on_git_repo(self, arguments):
         self._strict_assert(arguments.get('url'))
 
-        with tempdir() as workdir:
+        with TemporaryDirectory() as workdir:
             repo_url = arguments.get('url')
             repo = Git.clone(repo_url, path=workdir, depth=str(1))
             metadata = self.run_mercator(arguments, workdir,

--- a/tests/workers/test_cvecheck.py
+++ b/tests/workers/test_cvecheck.py
@@ -3,8 +3,9 @@ from flexmock import flexmock
 import os
 import pytest
 from shutil import copy
+from tempfile import TemporaryDirectory
+
 from f8a_worker.object_cache import EPVCache
-from f8a_worker.utils import tempdir
 from f8a_worker.workers import CVEcheckerTask
 
 
@@ -191,7 +192,7 @@ class TestCVEchecker(object):
         pkg_info = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 '..', 'data', 'pypi', 'salt-2016.11.6', 'PKG-INFO')
         args = {'ecosystem': 'pypi', 'name': 'salt', 'version': '2016.11.6'}
-        with tempdir() as extracted:
+        with TemporaryDirectory() as extracted:
             # We need a write-access into extracted/
             copy(pkg_info, extracted)
             flexmock(EPVCache).should_receive('get_extracted_source_tarball').and_return(extracted)


### PR DESCRIPTION
utils.tempdir is probably some Python 2 relic
Python-3.4's [tempfile.TemporaryDirectory](https://docs.python.org/3.4/library/tempfile.html#tempfile.TemporaryDirectory) should work exactly the same