### PR TITLE
Use centos/postgresql-94-centos7 instead of sclo/postgresql-94-centos7

### DIFF
--- a/hack/generate-db-migrations.sh
+++ b/hack/generate-db-migrations.sh
@@ -9,7 +9,7 @@ IMAGE_NAME="registry.devshift.net/bayesian/cucos-worker"
 MIGRATIONS_IMAGE_NAME="coreapi-worker-migrations"
 POSTGRES_CONTAINER_NAME="coreapi-migrations-postgres-${TIMESTAMP}"
 MIGRATIONS_CONTAINER_NAME="coreapi-worker-migrations-${TIMESTAMP}"
-POSTGRES_IMAGE_NAME="registry.centos.org/sclo/postgresql-94-centos7:latest"
+POSTGRES_IMAGE_NAME="registry.centos.org/centos/postgresql-94-centos7:latest"
 
 docker build --pull --tag=$IMAGE_NAME -f "${THISDIR}/../Dockerfile" "${THISDIR}/.."
 docker build -f "${THISDIR}/../Dockerfile.migrations" --tag=$MIGRATIONS_IMAGE_NAME "${THISDIR}/.."

--- a/runtest.sh
+++ b/runtest.sh
@@ -14,7 +14,7 @@ TIMESTAMP="$(date +%F-%H-%M-%S)"
 
 IMAGE_NAME=${IMAGE_NAME:-registry.devshift.net/bayesian/cucos-worker}
 TEST_IMAGE_NAME="worker-tests"
-POSTGRES_IMAGE_NAME="registry.centos.org/sclo/postgresql-94-centos7:latest"
+POSTGRES_IMAGE_NAME="registry.centos.org/centos/postgresql-94-centos7:latest"
 S3_IMAGE_NAME="minio/minio"
 CVEDB_S3_DUMP_IMAGE_NAME="registry.devshift.net/bayesian/cvedb-s3-dump"
 


### PR DESCRIPTION
Fixes:
```
Starting/creating containers:
+ docker run -d --env-file tests/postgres.env --name worker-tests-db-2018-03-01-16-28-51 registry.centos.org/sclo/postgresql-94-centos7:latest
Unable to find image 'registry.centos.org/sclo/postgresql-94-centos7:latest' locally
Trying to pull repository registry.centos.org/sclo/postgresql-94-centos7 ... 
Pulling repository registry.centos.org/sclo/postgresql-94-centos7
/usr/bin/docker-current: Error: image sclo/postgresql-94-centos7:latest not found.
```

Unlike https://registry.centos.org/centos/postgresql-94-centos7 the https://registry.centos.org/sclo/postgresql-94-centos7 is empty.

Not sure why we've been using the 'sclo' variant, but the tests as well as generating db migrations run OK with the 'centos' one.

For the one failing test see #541 