### PR TITLE
Store available results on S3, regardless of failure

### DIFF
--- a/f8a_worker/dispatcher/flows/bayesianPackageFlow.yml
+++ b/f8a_worker/dispatcher/flows/bayesianPackageFlow.yml
@@ -45,7 +45,11 @@
         - from: 'PackageResultCollector'
           to: 'PackageGraphImporterTask'
         - from: 'PackageFinalizeTaskError'
-          to: 'PackageGraphImporterTask'
+          to: 'PackageResultCollector'
+          condition:
+            name: 'argsFieldExist'
+            args:
+              key: 'document_id'
         - from: 'InitPackageFlow'
           to: 'PackageGraphImporterTask'
           condition:


### PR DESCRIPTION
The results from tasks that finished successfully were never stored on S3 if there was an error later on.