### PR TITLE
Minor enhancements in docstrings

### DIFF
--- a/check-docstyle.sh
+++ b/check-docstyle.sh
@@ -1,5 +1,6 @@
 directories="alembic f8a_worker tests hack"
 separate_files="setup.py"
+exclude_files="tests/data/license/license.py"
 pass=0
 fail=0
 
@@ -47,8 +48,7 @@ echo
 # checks for the whole directories
 for directory in $directories
 do
-    files=`find $directory -path $directory/venv -prune -o -name '*.py' -print`
-
+    files=`find $directory -path $directory/venv -prune -o -name '*.py' ! -path $exclude_files -print`
     check_files "$files"
 done
 

--- a/f8a_worker/setup_celery.py
+++ b/f8a_worker/setup_celery.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Selinon/Celery setup."""
+"""Functions to setup Selinon/Celery."""
 
 import os
 import logging

--- a/f8a_worker/storages/postgres_base.py
+++ b/f8a_worker/storages/postgres_base.py
@@ -127,7 +127,9 @@ class PostgresBase(DataStorage):
             raise
 
     def store_error(self, node_args, flow_name, task_name, task_id, exc_info):
-        """We do not store errors in init tasks.
+        """Store error info to the Postgress database.
+
+        Note: We do not store errors in init tasks.
 
         The reasoning is that init
         tasks are responsible for creating database entries. We cannot rely

--- a/f8a_worker/storages/s3.py
+++ b/f8a_worker/storages/s3.py
@@ -24,7 +24,7 @@ class AmazonS3(DataStorage):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, bucket_name=None,
                  region_name=None, endpoint_url=None, use_ssl=False, encryption=None,
                  versioned=None):
-        """Initialize object."""
+        """Initialize object, setup connection to the AWS S3."""
         # Priority for configuration options:
         #   1. environment variables
         #   2. arguments passed to constructor
@@ -148,11 +148,11 @@ class AmazonS3(DataStorage):
         self._s3 = None
 
     def retrieve(self, flow_name, task_name, task_id):
-        """Not implemented."""
+        """Retrieve data from the storage. Method needs to be implemented by descendent classes."""
         raise NotImplementedError()
 
     def store(self, node_args, flow_name, task_name, task_id, result):
-        """Not implemented."""
+        """Save data to the storage. Method that needs to be implemented by descendent classes."""
         raise NotImplementedError()
 
     @staticmethod

--- a/f8a_worker/storages/s3_crowd_source_tags.py
+++ b/f8a_worker/storages/s3_crowd_source_tags.py
@@ -12,7 +12,7 @@ class S3CrowdSourceTags(AmazonS3):
         return "{ecosystem}/github/data_input_raw_package_list/".format(ecosystem=ecosystem)
 
     def retrieve_package_topic(self, ecosystem):
-        """Retrieve package_topic.json."""
+        """Retrieve package_topic.json from the storage."""
         path = self.get_object_key_path(ecosystem)
         object_key = "{path}/package_topic.json".format(path=path)
         return self.retrieve_dict(object_key)

--- a/f8a_worker/storages/s3_description_repository.py
+++ b/f8a_worker/storages/s3_description_repository.py
@@ -17,7 +17,7 @@ class S3RepositoryDescription(AmazonS3):
         return self.retrieve_blob(object_key).decode()
 
     def store(self, node_args, flow_name, task_name, task_id, result):
-        """Store."""
+        """Save repository description into the storage."""
         assert 'ecosystem' in node_args
         assert 'name' in node_args
 

--- a/f8a_worker/storages/s3_gh_manifests.py
+++ b/f8a_worker/storages/s3_gh_manifests.py
@@ -27,6 +27,6 @@ class S3GitHubManifestMetadata(AmazonS3):
         return version_id
 
     def store_raw_manifest(self, ecosystem, repo_path, filename, manifest):
-        """Store manifest."""
+        """Store manifest as a blob into the AWS S3."""
         path = self.get_object_key_path(ecosystem, repo_path)
         self.store_blob(manifest, "{path}/{filename}".format(path=path, filename=filename))

--- a/f8a_worker/storages/s3_keywords_summary.py
+++ b/f8a_worker/storages/s3_keywords_summary.py
@@ -7,6 +7,6 @@ class S3KeywordsSummary(AmazonS3):
     """S3 storage for keywords summary."""
 
     def store(self, node_args, flow_name, task_name, task_id, result):
-        """Store."""
+        """Store the result into the AWS S3."""
         object_key = "{ecosystem}/{name}.json".format(**node_args)
         return self.store_dict(result, object_key)

--- a/f8a_worker/storages/s3_manifests.py
+++ b/f8a_worker/storages/s3_manifests.py
@@ -10,6 +10,7 @@ class S3Manifests(AmazonS3):
 
     @staticmethod
     def _construct_object_key(node_args, manifest):
+        """Construct object key path."""
         assert 'filename' in manifest
         return "{}/{}".format(node_args['external_request_id'], manifest['filename'])
 

--- a/f8a_worker/storages/s3_readme.py
+++ b/f8a_worker/storages/s3_readme.py
@@ -12,7 +12,7 @@ class S3Readme(AmazonS3):
         return "{ecosystem}/{name}/README.json".format(**arguments)
 
     def retrieve_readme_json(self, ecosystem, name):
-        """Retrieve README.json."""
+        """Retrieve README.json from the storage."""
         object_key = self._construct_object_key(ecosystem=ecosystem, name=name)
         return self.retrieve_dict(object_key)
 

--- a/f8a_worker/storages/s3_temp_artifacts.py
+++ b/f8a_worker/storages/s3_temp_artifacts.py
@@ -29,7 +29,7 @@ class S3TempArtifacts(AmazonS3):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, bucket_name=None,
                  region_name=None, endpoint_url=None, use_ssl=False, encryption=None,
                  versioned=None, days_to_expire=None):
-        """Initialize object."""
+        """Construct for this class, initializes the connection to S3 and set expiration rules."""
         super().__init__(aws_access_key_id=aws_access_key_id,
                          aws_secret_access_key=aws_secret_access_key,
                          bucket_name=bucket_name, region_name=region_name,

--- a/f8a_worker/workers/CVEchecker.py
+++ b/f8a_worker/workers/CVEchecker.py
@@ -358,7 +358,11 @@ class CVEcheckerTask(BaseTask):
         return self._query_ossindex(arguments)
 
     def execute(self, arguments):
-        """Tasks workhorse."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('version'))

--- a/f8a_worker/workers/binwalk.py
+++ b/f8a_worker/workers/binwalk.py
@@ -57,7 +57,7 @@ class BinwalkTask(BaseTask):
 
     @staticmethod
     def parse_binwalk(output):
-        """Parse binwalk tool output."""
+        """Parse binwalk tool output and accumulate descriptions."""
         if not output:
             return None
         import re
@@ -70,7 +70,11 @@ class BinwalkTask(BaseTask):
         return matched
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('version'))

--- a/f8a_worker/workers/bookkeeper.py
+++ b/f8a_worker/workers/bookkeeper.py
@@ -62,7 +62,11 @@ class BookkeeperTask(BaseTask):
                 continue
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('external_request_id'))
         self._strict_assert(arguments.get('data'))
 

--- a/f8a_worker/workers/code_metrics.py
+++ b/f8a_worker/workers/code_metrics.py
@@ -336,7 +336,11 @@ class CodeMetricsTask(BaseTask):
     }
 
     def execute(self, arguments):
-        """Start the task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('version'))

--- a/f8a_worker/workers/dependency_parser.py
+++ b/f8a_worker/workers/dependency_parser.py
@@ -13,7 +13,11 @@ class GithubDependencyTreeTask(BaseTask):
     """Finds out direct and indirect dependencies from a given github repository."""
 
     def execute(self, arguments=None):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('github_repo'))
         self._strict_assert(arguments.get('github_sha'))
         self._strict_assert(arguments.get('email_ids'))

--- a/f8a_worker/workers/dependency_snapshot.py
+++ b/f8a_worker/workers/dependency_snapshot.py
@@ -80,7 +80,11 @@ class DependencySnapshotTask(BaseTask):
         return ret
 
     def execute(self, arguments):
-        """Start the task that analyzes dependencies."""
+        """Start the task that analyzes dependencies.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
 
         result = {'summary': {'errors': [], 'dependency_counts': {}},

--- a/f8a_worker/workers/digester.py
+++ b/f8a_worker/workers/digester.py
@@ -59,7 +59,11 @@ class DigesterTask(BaseTask):
         return f_digests
 
     def execute(self, arguments):
-        """Task's workhorse."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('version'))

--- a/f8a_worker/workers/gh_metadata_init.py
+++ b/f8a_worker/workers/gh_metadata_init.py
@@ -9,7 +9,11 @@ class InitGitHubManifestMetadata(BaseTask):
     """Initialize Analysis."""
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('url'))
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('repo_name'))

--- a/f8a_worker/workers/git_stats.py
+++ b/f8a_worker/workers/git_stats.py
@@ -127,7 +127,11 @@ class GitStats(BaseTask):
         }
 
     def execute(self, arguments):
-        """Execute the task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert('ecosystem' in arguments)
         self._strict_assert('name' in arguments)
         self._strict_assert('url' in arguments)

--- a/f8a_worker/workers/githuber.py
+++ b/f8a_worker/workers/githuber.py
@@ -68,7 +68,11 @@ class GithubTask(BaseTask):
         return parsed
 
     def execute(self, arguments):
-        """Task's workhorse."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         result_data = {'status': 'unknown',
                        'summary': [],
                        'details': {}}

--- a/f8a_worker/workers/graph_importer.py
+++ b/f8a_worker/workers/graph_importer.py
@@ -22,7 +22,11 @@ class GraphImporterTask(BaseTask):
         endpoint=_SELECTIVE_SERVICE_ENDPOINT)
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('document_id'))

--- a/f8a_worker/workers/graph_sync.py
+++ b/f8a_worker/workers/graph_sync.py
@@ -8,7 +8,11 @@ class GraphSyncTask(BaseTask):
     """Sync package data to graph database."""
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         _RETRY_COUNTDOWN = 10
 
         ecosystem = arguments.get['ecosystem']

--- a/f8a_worker/workers/graphaggregator.py
+++ b/f8a_worker/workers/graphaggregator.py
@@ -32,7 +32,11 @@ class GraphAggregatorTask(BaseTask):
         return [{"package": k, "version": v} for k, v in versions.items()]
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('data'))
         self._strict_assert(arguments.get('external_request_id'))
 

--- a/f8a_worker/workers/init_analysis_flow.py
+++ b/f8a_worker/workers/init_analysis_flow.py
@@ -15,7 +15,11 @@ class InitAnalysisFlow(BaseTask):
     """Download source and start whole analysis."""
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('version'))
         self._strict_assert(arguments.get('ecosystem'))

--- a/f8a_worker/workers/init_package_flow.py
+++ b/f8a_worker/workers/init_package_flow.py
@@ -95,7 +95,11 @@ class InitPackageFlow(BaseTask):
         return entry
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('ecosystem'))
 

--- a/f8a_worker/workers/keywords_summary.py
+++ b/f8a_worker/workers/keywords_summary.py
@@ -85,7 +85,11 @@ class KeywordsSummaryTask(BaseTask):
         }
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
 

--- a/f8a_worker/workers/keywords_tagging.py
+++ b/f8a_worker/workers/keywords_tagging.py
@@ -140,7 +140,11 @@ class KeywordsTaggingTask(KeywordsTaggingTaskBase):
         return details
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('version'))
@@ -215,7 +219,11 @@ class PackageKeywordsTaggingTask(KeywordsTaggingTaskBase):
         return details
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
 

--- a/f8a_worker/workers/libraries_io.py
+++ b/f8a_worker/workers/libraries_io.py
@@ -20,7 +20,11 @@ class LibrariesIoTask(BaseTask):
         return sorted(versions, key=itemgetter('published_at'))[-count:]
 
     def execute(self, arguments):
-        """Task entrypoint."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
 

--- a/f8a_worker/workers/license.py
+++ b/f8a_worker/workers/license.py
@@ -84,7 +84,11 @@ class LicenseCheckTask(BaseTask):
         return result_data
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('version'))

--- a/f8a_worker/workers/linguist.py
+++ b/f8a_worker/workers/linguist.py
@@ -66,7 +66,11 @@ class LinguistTask(BaseTask):
         return data
 
     def execute(self, arguments):
-        """Start the task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
         self._strict_assert(arguments.get('version'))

--- a/f8a_worker/workers/manifest_keeper.py
+++ b/f8a_worker/workers/manifest_keeper.py
@@ -13,7 +13,11 @@ class ManifestKeeperTask(BaseTask):
     add_audit_info = False
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('external_request_id'))
 
         postgres = StoragePool.get_connected_storage('BayesianPostgres')

--- a/f8a_worker/workers/repository_description.py
+++ b/f8a_worker/workers/repository_description.py
@@ -64,7 +64,11 @@ class RepositoryDescCollectorTask(BaseTask):
     }
 
     def execute(self, arguments):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         self._strict_assert(arguments.get('ecosystem'))
         self._strict_assert(arguments.get('name'))
 

--- a/f8a_worker/workers/stackaggregator_v2.py
+++ b/f8a_worker/workers/stackaggregator_v2.py
@@ -385,7 +385,11 @@ class StackAggregatorV2Task(BaseTask):
     _analysis_name = 'stack_aggregator_v2'
 
     def execute(self, arguments=None):
-        """Execute task."""
+        """Task code.
+
+        :param arguments: dictionary with task arguments
+        :return: {}, results
+        """
         stack_data = []
         aggregated = self.parent_task_result('GraphAggregatorTask')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Configuration for unit tests."""
+
 import pytest
 from flexmock import flexmock
 
@@ -13,6 +15,7 @@ from selinon import Config
 
 @pytest.fixture
 def rdb():
+    """Provide connection to a database."""
     session = create_db_scoped_session()
     # TODO: we may need to run actual migrations here
     # make sure all session objects from scoped_session get closed here
@@ -32,6 +35,7 @@ def rdb():
 
 @pytest.fixture
 def maven(rdb):
+    """Prepare database with Maven ecosystem."""
     maven = Ecosystem(name='maven', backend=EcosystemBackend.maven,
                       fetch_url='')
     rdb.add(maven)
@@ -41,6 +45,7 @@ def maven(rdb):
 
 @pytest.fixture
 def npm(rdb):
+    """Prepare database with NPM ecosystem."""
     npm = Ecosystem(name='npm', backend=EcosystemBackend.npm,
                     fetch_url='https://registry.npmjs.org/')
     rdb.add(npm)
@@ -50,6 +55,7 @@ def npm(rdb):
 
 @pytest.fixture
 def pypi(rdb):
+    """Prepare database with Pypi ecosystem."""
     pypi = Ecosystem(name='pypi', backend=EcosystemBackend.pypi,
                      fetch_url='https://pypi.python.org/pypi')
     rdb.add(pypi)
@@ -59,6 +65,7 @@ def pypi(rdb):
 
 @pytest.fixture
 def rubygems(rdb):
+    """Prepare database with Ruby gems ecosystem."""
     rubygems = Ecosystem(name='rubygems', backend=EcosystemBackend.rubygems,
                          fetch_url='https://rubygems.org/api/v1')
     rdb.add(rubygems)
@@ -68,6 +75,7 @@ def rubygems(rdb):
 
 @pytest.fixture
 def nuget(rdb):
+    """Prepare database with Nuget ecosystem."""
     nuget = Ecosystem(name='nuget', backend=EcosystemBackend.nuget,
                       fetch_url='https://api.nuget.org/packages/')
     rdb.add(nuget)
@@ -77,6 +85,7 @@ def nuget(rdb):
 
 @pytest.fixture
 def go(rdb):
+    """Prepare database with Go ecosystem."""
     e = Ecosystem(name='go', backend=EcosystemBackend.scm, fetch_url='')
     rdb.add(e)
     rdb.commit()
@@ -92,4 +101,5 @@ def dispatcher_setup():
 
 @pytest.fixture()
 def no_s3_connection():
+    """Mock the connection to S3."""
     flexmock(AmazonS3).should_receive('is_connected').and_return(True)

--- a/tests/data/schemas/generate.py
+++ b/tests/data/schemas/generate.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+"""Script to generate all new schemas for workers."""
+
 from collections import OrderedDict
 import json
 from pathlib import Path

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,24 +19,30 @@ from f8a_worker.schemas import (SchemaRef, SchemaLibrary,
 
 @pytest.mark.offline
 class TestSchemaRef(object):
+    """Tests for the SchemaRef class."""
 
     def test_next_addition(self):
+        """Tests for the method SchemaRef.next_addition."""
         schema_ref = SchemaRef("example", "1-0-0")
         assert schema_ref.next_addition() == SchemaRef("example", "1-0-1")
 
     def test_next_revision(self):
+        """Tests for the method SchemaRef.next_revision."""
         schema_ref = SchemaRef("example", "1-0-0")
         assert schema_ref.next_revision() == SchemaRef("example", "1-1-0")
 
     def test_next_model(self):
+        """Tests for the method SchemaRef.next_model."""
         schema_ref = SchemaRef("example", "1-0-0")
         assert schema_ref.next_model() == SchemaRef("example", "2-0-0")
 
 
 @pytest.mark.offline
 class TestSchemaLibrary(object):
+    """Tests for the SchemaLibrary class."""
 
     def test_schema_lookup(self, tmpdir):
+        """Tests for schema lookup."""
         library = SchemaLibrary(str(tmpdir))
         requested_schema = SchemaRef("example", "1-0-0")
         with pytest.raises(SchemaLookupError):
@@ -49,6 +55,7 @@ class TestSchemaLibrary(object):
         assert library.load_schema(requested_schema) == dummy_schema
 
     def test_bundled_schema_lookup(self, tmpdir):
+        """Tests for bundled schema lookup."""
         pkgdir = tmpdir.mkdir(tmpdir.basename)
         pkgdir.ensure("__init__.py")
         schemadir = pkgdir.mkdir("schemas")
@@ -65,6 +72,7 @@ class TestSchemaLibrary(object):
         assert library.load_schema(requested_schema) == dummy_schema
 
     def test_bundled_dynamic_schema_lookup(self, tmpdir, monkeypatch):
+        """Tests for bundled dynamic schema lookup."""
         pkgdir = tmpdir.mkdir(tmpdir.basename)
         pkgdir.ensure("__init__.py")
         schemadir = pkgdir.mkdir("schemas")
@@ -108,6 +116,8 @@ class TestSchemaLibrary(object):
 
 @pytest.mark.offline
 class TestGeneratedSchemas(object):
+    """Tests for all already generated worker schemas."""
+
     schemas_path = os.path.join("data", "schemas")
 
     def test_dynamic_schemas_against_generated(self):
@@ -126,5 +136,9 @@ class TestGeneratedSchemas(object):
 
 @pytest.mark.offline
 class TestSchemaSequence:
+    """Tests for the function assert_no_two_consecutive_schemas_are_same."""
+
     def test_no_two_consecutive_schemas_are_same(self):
+        """Test the function assert_no_two_consecutive_schemas_are_same for all worker schemas."""
         assert_no_two_consecutive_schemas_are_same(load_all_worker_schemas)
+    # TODO: test for wrong input, test for empty list of schemas etc.

--- a/tests/workers/_test_csmock.py
+++ b/tests/workers/_test_csmock.py
@@ -1,3 +1,5 @@
+"""Tests for classes and functions from the csmock_worker module."""
+
 import json
 import os
 
@@ -24,11 +26,13 @@ dummy_results_path = os.path.join(
 
 
 def mock_csmock(args):
+    """Read mock data from JSON file."""
     with open(dummy_results_path) as fp:
         return json.load(fp)
 
 
 def test_csmock_tool(tmpdir):
+    """Test for the StaticAnalysis class."""
     t = str(tmpdir)
     os.chdir(t)
     sa = csmock_worker.StaticAnalysis(dummy_package_path)
@@ -41,6 +45,7 @@ def test_csmock_tool(tmpdir):
 
 @pytest.mark.offline
 def test_offline_csmock_tool():
+    """Test for the StaticAnalysis class."""
     flexmock.flexmock(csmock_worker, csmock=mock_csmock)
     task = csmock_worker.StaticAnalysis(dummy_package_path)
     results = task.analyze()
@@ -51,6 +56,7 @@ def test_offline_csmock_tool():
 
 
 def test_csmock_worker(tmpdir):
+    """Start the CsmockTask with package from PyPi and check its result."""
     six_tb_url = "https://pypi.python.org/packages/b3/b2/" + \
         "238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz"
     tb_path = os.path.join(str(tmpdir), "six-1.10.0.tar.gz")
@@ -79,6 +85,7 @@ def test_csmock_worker(tmpdir):
 
 @pytest.mark.offline
 def test_offline_csmock_worker(tmpdir):
+    """Start the CsmockTask with mock data and check its result."""
     flexmock.flexmock(csmock_worker, csmock=mock_csmock)
     t = csmock_worker.CsmockTask.create_test_instance(task_name='static_analysis')
     args = {'source_tarball_path': dummy_package_path, 'cache_path': str(tmpdir)}

--- a/tests/workers/test_bigquery_gh.py
+++ b/tests/workers/test_bigquery_gh.py
@@ -1,3 +1,5 @@
+"""Tests for BigQueryProject and BigQueryTask classes."""
+
 from flexmock import flexmock
 from pathlib import Path
 import pytest
@@ -7,15 +9,18 @@ from f8a_worker.workers.bigquery_gh import BigQueryProject, BigQueryTask, comput
 
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestBigQueryGH(object):
+    """Tests for BigQueryProject and BigQueryTask classes."""
 
     json_key = str(Path(__file__).parent.parent / 'data/bigquery.json')
 
     def test_project_id(self):
+        """Test if the project_id property is set up properly."""
         flexmock(f8a_worker.workers.bigquery_gh).should_receive('get_client').once()
         bq = BigQueryProject(json_key=TestBigQueryGH.json_key)
         assert bq.project_id == 'test-project-000001'
 
     def test_process_results(self):
+        """Start the BigQueryTask task and check its results."""
         data = [{'name': 'underscore', 'version': '1.8.3', 'count': 101},
                 {'name': 'isarray', 'version': '2.0.2', 'count': 345}]
 
@@ -36,4 +41,5 @@ class TestBigQueryGH(object):
         ([1, 1, 1, 2, 5, 5, 11, 11, 17, 21], {1: 30, 2: 40, 5: 60, 11: 80, 17: 90, 21: 100})
     ])
     def test_compute_percentile_ranks(self, test_input, expected):
+        """Check the behaviour of function workers.bigquery_gh.compute_percentile_ranks."""
         assert compute_percentile_ranks(test_input) == expected

--- a/tests/workers/test_binwalk.py
+++ b/tests/workers/test_binwalk.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Tests for the BinwalkTask worker task."""
+
 import os
 import pytest
 from flexmock import flexmock
@@ -8,15 +10,19 @@ from f8a_worker.workers import BinwalkTask
 
 
 def is_executable(fpath):
+    """Check if the given file is executable."""
     return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
 
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestBinwalk(object):
+    """Tests for the BinwalkTask worker task."""
+
     @pytest.mark.skipif(not os.path.isfile('/usr/bin/binwalk'),
                         reason="requires binwalk")
     @pytest.mark.usefixtures("no_s3_connection")
     def test_execute(self):
+        """Start the BinwalkTask worker task and test its result."""
         path = os.path.join(
                    os.path.dirname(
                        os.path.abspath(__file__)), '..', '..', 'hack')  # various executable scripts

--- a/tests/workers/test_cvecheck.py
+++ b/tests/workers/test_cvecheck.py
@@ -1,3 +1,5 @@
+"""Tests for the CVEcheckerTask worker task."""
+
 from datadiff.tools import assert_equal
 from flexmock import flexmock
 from pathlib import Path
@@ -11,11 +13,14 @@ from f8a_worker.workers import CVEcheckerTask
 
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestCVEchecker(object):
+    """Tests for the CVEcheckerTask worker task."""
+
     @pytest.mark.parametrize(('cve_id', 'score', 'vector', 'severity'), [
         ('CVE-2017-0249', 7.3, 'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L', 'high'),
         ('cve-2015-1164', 4.3, 'AV:N/AC:M/Au:N/C:N/I:P/A:N', 'medium')
     ])
     def test_get_cve_impact(self, cve_id, score, vector, severity):
+        """Test the method CVEcheckerTask.get_cve_impact."""
         score_, vector_, severity_ = CVEcheckerTask.get_cve_impact(cve_id)
         assert score_ == score
         assert vector_ == vector
@@ -23,6 +28,7 @@ class TestCVEchecker(object):
 
     @pytest.mark.usefixtures('npm')
     def test_npm_geddy(self):
+        """Tests CVE reports for selected package from NPM ecosystem."""
         args = {'ecosystem': 'npm', 'name': 'geddy', 'version': '13.0.7'}
         task = CVEcheckerTask.create_test_instance(task_name='security_issues')
         results = task.execute(args)
@@ -56,6 +62,7 @@ class TestCVEchecker(object):
         assert_equal(results.get('details'), expected_details)
 
     def test_maven_commons_collections(self):
+        """Tests CVE reports for selected packages from Maven ecosystem."""
         jar_path = str(Path(__file__).parent.parent / 'data/maven/commons-collections-3.2.1.jar')
         args = {'ecosystem': 'maven', 'name': 'commons-collections:commons-collections',
                 'version': '3.2.1'}
@@ -138,6 +145,7 @@ class TestCVEchecker(object):
         assert_equal(results.get('details'), expected_details)
 
     def test_python_mako(self):
+        """Tests CVE reports for selected package from PyPi ecosystem."""
         extracted = str(Path(__file__).parent.parent / 'data/pypi/Mako-0.3.3')
         args = {'ecosystem': 'pypi', 'name': 'mako', 'version': '0.3.3'}
         flexmock(EPVCache).should_receive('get_extracted_source_tarball').and_return(extracted)
@@ -292,6 +300,7 @@ class TestCVEchecker(object):
 
     @pytest.mark.usefixtures('nuget')
     def test_nuget_system_net_http(self):
+        """Tests CVE reports for selected package from Nuget ecosystem."""
         args = {'ecosystem': 'nuget', 'name': 'System.Net.Http', 'version': '4.1.1'}
         task = CVEcheckerTask.create_test_instance(task_name='security_issues')
         results = task.execute(arguments=args)

--- a/tests/workers/test_githuber.py
+++ b/tests/workers/test_githuber.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Tests for the GithubTask worker task."""
+
 import pytest
 
 from f8a_worker.workers import GithubTask
@@ -7,11 +9,13 @@ from f8a_worker.workers import GithubTask
 
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestGithuber(object):
+    """Tests for the GithubTask worker task."""
 
     @pytest.mark.parametrize(('repo_name', 'repo_url'), [
         ('projectatomic/atomic-reactor', 'https://github.com/projectatomic/atomic-reactor'),
     ])
     def test_execute(self, repo_name, repo_url):
+        """Start the GithubTask worker task and test its results."""
         task = GithubTask.create_test_instance(repo_name, repo_url)
         results = task.execute(arguments={})
         assert results is not None

--- a/tests/workers/test_licensecheck.py
+++ b/tests/workers/test_licensecheck.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Tests for the LicenseCheckTask worker task."""
+
 import jsonschema
 from flexmock import flexmock
 from pathlib import Path
@@ -13,9 +15,11 @@ from f8a_worker.object_cache import EPVCache
 @pytest.mark.offline
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestLicenseCheck(object):
+    """Tests for the LicenseCheckTask worker task."""
 
     @pytest.mark.usefixtures("no_s3_connection")
     def test_error(self):
+        """Start the LicenseCheckTask worker task with improper parameters and test its results."""
         data = "/this-is-not-a-real-directory"
         args = dict.fromkeys(('ecosystem', 'name', 'version'), 'some-value')
         flexmock(EPVCache).should_receive('get_sources').and_return(data)
@@ -27,6 +31,7 @@ class TestLicenseCheck(object):
                         reason="requires scancode")
     @pytest.mark.usefixtures("no_s3_connection")
     def test_execute(self):
+        """Start the LicenseCheckTask task and test its results."""
         data = str(Path(__file__).parent.parent / 'data/license')
         args = dict.fromkeys(('ecosystem', 'name', 'version'), 'some-value')
         flexmock(EPVCache).should_receive('get_sources').and_return(data)

--- a/tests/workers/test_linguist.py
+++ b/tests/workers/test_linguist.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Tests for the LinguistTask worker task."""
+
 from os.path import isfile
 import pytest
 from flexmock import flexmock
@@ -15,10 +18,13 @@ MODULE_VERSION = '1.10.0'
 
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestLinguist(object):
+    """Tests for the LinguistTask worker task."""
+
     @pytest.mark.skipif(not isfile('/usr/local/bin/linguist'),
                         reason="requires linguist")
     @pytest.mark.usefixtures("no_s3_connection")
     def test_execute(self, tmpdir):
+        """Start the LinguistTask worker task and check its results."""
         IndianaJones.fetch_artifact(
             ecosystem=ECOSYSTEM, artifact=MODULE_NAME,
             version=MODULE_VERSION, target_dir=str(tmpdir))

--- a/tests/workers/test_mercator.py
+++ b/tests/workers/test_mercator.py
@@ -1,3 +1,5 @@
+"""Tests for the MercatorTask worker task."""
+
 from pathlib import Path
 import pytest
 from flexmock import flexmock
@@ -7,6 +9,7 @@ from f8a_worker.workers.mercator import MercatorTask
 
 
 def compare_dictionaries(a, b):
+    """Compare two dictionaries (shape+content)."""
     def mapper(item):
         if isinstance(item, list):
             return frozenset(map(mapper, item))
@@ -19,11 +22,15 @@ def compare_dictionaries(a, b):
 
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestMercator(object):
+    """Tests for the MercatorTask worker task."""
+
     def setup_method(self, method):
+        """Set up the MercatorTask."""
         self.m = MercatorTask.create_test_instance(task_name='metadata')
 
     @pytest.mark.usefixtures("no_s3_connection")
     def test_execute_npm(self, tmpdir, npm):
+        """Test the MercatorTask for the NPM ecosystem."""
         name = 'wrappy'
         version = '1.0.2'
         required = {'homepage', 'version', 'declared_licenses', 'code_repository',
@@ -42,6 +49,7 @@ class TestMercator(object):
 
     @pytest.mark.usefixtures("no_s3_connection")
     def test_execute_maven(self, maven):
+        """Test the MercatorTask for the Maven ecosystem."""
         pom_path = str(Path(__file__).parent.parent / 'data/maven/com.networknt/mask/pom.xml')
         name = 'com.networknt:mask'
         version = '1.1.0'
@@ -67,6 +75,7 @@ class TestMercator(object):
 
     @pytest.mark.usefixtures("no_s3_connection")
     def test_execute_go(self, go):
+        """Test the MercatorTask for the Go ecosystem."""
         path = str(Path(__file__).parent.parent / 'data/go/mercator-go')
         args = {'ecosystem': go.name, 'name': 'dummy', 'version': 'dummy'}
         flexmock(EPVCache).should_receive('get_extracted_source_tarball').and_return(path)

--- a/tests/workers/test_oscryptocatcher.py
+++ b/tests/workers/test_oscryptocatcher.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Tests for the OSCryptoCatcherTask worker task."""
+
 from __future__ import unicode_literals
 import os
 import sys
@@ -10,10 +13,13 @@ from f8a_worker.object_cache import EPVCache
 
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestOSCryptoCatcher(object):
+    """Tests for the OSCryptoCatcherTask worker task."""
+
     @pytest.mark.skipif(not os.path.isfile('/usr/bin/oscryptocatcher'),
                         reason="requires oscryptocatcher")
     @pytest.mark.usefixtures("no_s3_connection")
     def test_ssl_py(self):
+        """Start the OSCryptoCatcherTask worker task and test its results."""
         path = sys.modules['ssl'].__file__  # /usr/lib64/python2.7/ssl.pyc
         args = dict.fromkeys(('ecosystem', 'name', 'version'), 'some-value')
         flexmock(EPVCache).should_receive('get_extracted_source_tarball').and_return(path)

--- a/tests/workers/test_recurse.py
+++ b/tests/workers/test_recurse.py
@@ -1,7 +1,10 @@
+"""Tests for the function f8a_worker.dispatcher.foreach._is_url_dependency."""
+
 from f8a_worker.dispatcher.foreach import _is_url_dependency
 
 
 def test__is_url_dependency():
+    """Test for the function f8a_worker.dispatcher.foreach._is_url_dependency."""
     data = [
         ({"name": "test2", "version": "1.0.0"}, False),
         ({"name": "test3", "version": "http://some.tar/ball.tgz"}, True),
@@ -11,3 +14,4 @@ def test__is_url_dependency():
 
     for d, is_url_dep in data:
         assert _is_url_dependency(d) == is_url_dep
+    # TODO: check how improper input is handled

--- a/tests/workers/test_repository_description.py
+++ b/tests/workers/test_repository_description.py
@@ -1,3 +1,5 @@
+"""Test for the RepositoryDescCollectorTask worker task."""
+
 import pytest
 
 from selinon import FatalTaskError
@@ -6,11 +8,14 @@ from f8a_worker.workers import RepositoryDescCollectorTask
 
 @pytest.mark.usefixtures("dispatcher_setup")
 class TestRepositoryDescCollectorTask(object):
+    """Test for the RepositoryDescCollectorTask worker task."""
+
     @pytest.mark.parametrize('args', [
          {'ecosystem': 'npm', 'name': 'serve-static'},
          {'ecosystem': 'pypi', 'name': 'celery'}
     ])
     def test_execute(self, args):
+        """Start the RepositoryDescCollectorTask worker task using given arguments."""
         task = RepositoryDescCollectorTask.create_test_instance(
             task_name='RepositoryDescCollectorTask')
         result = task.execute(arguments=args)
@@ -25,6 +30,7 @@ class TestRepositoryDescCollectorTask(object):
           'name': 'somenonexistentpackagethatwillneverexisreallyreallywontexist'}
     ])
     def test_execute_nonexistent(self, args):
+        """Test the RepositoryDescCollectorTask behaviour for non existent packages."""
         task = RepositoryDescCollectorTask.create_test_instance(
             task_name='RepositoryDescCollectorTask')
 
@@ -37,6 +43,7 @@ class TestRepositoryDescCollectorTask(object):
          {'ecosystem': 'go', 'name': 'bar'}
     ])
     def test_execute_unsupported_ecosystem(self, args):
+        """Test the RepositoryDescCollectorTask behaviour for unsupported ecosystems."""
         task = RepositoryDescCollectorTask.create_test_instance(
             task_name='RepositoryDescCollectorTask')
 


### PR DESCRIPTION
Actual output of pydoc checker:

```
----------------------------------------------------
Checking documentation strings in all sources stored
in following directories:
alembic f8a_worker tests hack
----------------------------------------------------

Using base prefix '/usr'
New python executable in /home/ptisnovs/bayesian/my/fabric8-analytics-worker/venv/bin/python3
Not overwriting existing python script /home/ptisnovs/bayesian/my/fabric8-analytics-worker/venv/bin/python (you must use /home/ptisnovs/bayesian/my/fabric8-analytics-worker/venv/bin/python3)
Installing setuptools, pip, wheel...done.
Running virtualenv with interpreter /usr/bin/python3
Requirement already satisfied: pydocstyle in ./venv/lib/python3.6/site-packages
Requirement already satisfied: six in ./venv/lib/python3.6/site-packages (from pydocstyle)
Requirement already satisfied: snowballstemmer in ./venv/lib/python3.6/site-packages (from pydocstyle)
alembic/versions/f5c853b83d41_add_api_requests_table.py
0
    Pass
alembic/versions/9d605c7725d8_add_app_stack_tables.py
0
    Pass
alembic/versions/76c5fd72744e_gh_usage_stats.py
0
    Pass
alembic/versions/0ff7fe2828a5_initial_revision.py
0
    Pass
alembic/versions/e48c7b4235aa_drop_analysisrequest_table.py
0
    Pass
alembic/versions/727aeeb88b2f_add_started_at_and_ended_at_to_.py
0
    Pass
alembic/versions/be06b06767de_add_indexes_on_foreign_keys_in_.py
0
    Pass
alembic/versions/2bd5f6d0c8b0_introduce_stackreq_origin_flag.py
0
    Pass
alembic/versions/e2762a61d34c_upstream_url_can_be_null.py
0
    Pass
alembic/versions/49c27b67936f_permissions.py
0
    Pass
alembic/versions/33b719488061_add_col_dep_snapshot.py
0
    Pass
alembic/versions/ea55c632ae8d_create_auth_data.py
0
    Pass
alembic/versions/d62464ca17ae_introduce_error_flag_for_worker_results.py
0
    Pass
alembic/versions/ddb09a7d6633_delete_unnecessary_db_tables.py
0
    Pass
alembic/versions/813f9a704eb7_stack_request_coltypechange.py
0
    Pass
alembic/versions/b4fbc8e04c81_gh_usage_with_versions.py
0
    Pass
alembic/versions/a0433904c63b_analysis_requests.py
0
    Pass
alembic/versions/750621a9cd89_drop_server_tables.py
0
    Pass
alembic/versions/133cd5484609_add_es_marker.py
0
    Pass
alembic/versions/b19a6deb869d_stack_request_coltype_change.py
0
    Pass
alembic/versions/fc7ea2a7e386_analytics_tables.py
0
    Pass
alembic/versions/245b57b274c2_introduce_upstream_monitoring_flows.py
0
    Pass
alembic/versions/a31c98c74ea0_add_e_p_v.py
0
    Pass
alembic/versions/f8bb0efac483_nuget_ecosystem.py
0
    Pass
alembic/versions/3fd95b3a69f5_bye_reviews.py
0
    Pass
alembic/versions/47f4ce1e8d75_stack_analyses_request.py
0
    Pass
alembic/versions/2ff043a5af5b_make_ecosystem_name_unique.py
0
    Pass
alembic/versions/02b91e918b43_migrate_to_dynamic_control_flow.py
0
    Pass
alembic/versions/49fb7de6227f_removal_of_anitya.py
0
    Pass
alembic/versions/60b296cac700_add_similar_components_table.py
0
    Pass
alembic/versions/424427c5f988_relative_usage.py
0
    Pass
alembic/versions/79d88d57baa7_remove_analyses_column.py
0
    Pass
alembic/versions/cd05b43f27e5_add_synced2graph_boolean_column_to_.py
0
    Pass
alembic/versions/8302d3bb5f68_stackreq_team_result.py
0
    Pass
alembic/versions/01404498814b_create_epv_and_workerresult_indexes.py
0
    Pass
alembic/versions/7c643a1823db_index_on_external_request_id.py
0
    Pass
alembic/versions/20cf59abbda8_add_external_reqeust_id_to_workerresult.py
0
    Pass
alembic/versions/a46a17bfd29b_batches_versions_relation.py
0
    Pass
alembic/versions/a60f15a395e2_do_not_index_ecosystem_url.py
0
    Pass
alembic/versions/967036f90ba1_gemini_model_py.py
0
    Pass
alembic/versions/3eb32f202f93_removing_starttime_and_endtime.py
0
    Pass
alembic/versions/094ea67a2baf_add_index_for_synced2graph_column.py
0
    Pass
alembic/versions/da53445aabad_add_recommendation_feedback_py.py
0
    Pass
alembic/versions/963d3d929b19_analyses.py
0
    Pass
alembic/versions/5cf8c7dac1b6_remove_active_flag.py
0
    Pass
alembic/versions/6e7ff4c3177e_remove_batches.py
0
    Pass
alembic/versions/51cb05927271_downstream_map.py
0
    Pass
alembic/versions/21b3add12b10_initial_ref_stack_support.py
0
    Pass
alembic/versions/22a1cd66a9c6_batches_reviews.py
0
    Pass
alembic/env.py
0
    Pass
f8a_worker/object_cache.py
0
    Pass
f8a_worker/models.py
0
    Pass
f8a_worker/dispatcher/__init__.py
0
    Pass
f8a_worker/dispatcher/selective.py
0
    Pass
f8a_worker/dispatcher/trace.py
0
    Pass
f8a_worker/dispatcher/predicates.py
0
    Pass
f8a_worker/dispatcher/foreach.py
0
    Pass
f8a_worker/graphutils.py
0
    Pass
f8a_worker/__init__.py
0
    Pass
f8a_worker/utils.py
0
    Pass
f8a_worker/setup_celery.py
0
    Pass
f8a_worker/start.py
0
    Pass
f8a_worker/solver.py
0
    Pass
f8a_worker/process.py
0
    Pass
f8a_worker/manifests.py
0
    Pass
f8a_worker/base.py
0
    Pass
f8a_worker/storages/s3_mavenindex.py
0
    Pass
f8a_worker/storages/s3_data_base.py
0
    Pass
f8a_worker/storages/s3_crowd_source_tags.py
0
    Pass
f8a_worker/storages/s3_readme.py
0
    Pass
f8a_worker/storages/__init__.py
0
    Pass
f8a_worker/storages/s3_package_data.py
0
    Pass
f8a_worker/storages/s3_keywords_summary.py
0
    Pass
f8a_worker/storages/s3_manifests.py
0
    Pass
f8a_worker/storages/postgres_base.py
0
    Pass
f8a_worker/storages/s3_userintent.py
0
    Pass
f8a_worker/storages/s3_userprofilestore.py
0
    Pass
f8a_worker/storages/s3_description_repository.py
0
    Pass
f8a_worker/storages/package_postgres.py
0
    Pass
f8a_worker/storages/s3_temp_artifacts.py
0
    Pass
f8a_worker/storages/s3_bigquery.py
0
    Pass
f8a_worker/storages/s3_vulndb.py
0
    Pass
f8a_worker/storages/s3_artifacts.py
0
    Pass
f8a_worker/storages/s3_data.py
0
    Pass
f8a_worker/storages/s3_manual_tagging.py
0
    Pass
f8a_worker/storages/s3_gh_manifests.py
0
    Pass
f8a_worker/storages/postgres.py
0
    Pass
f8a_worker/storages/s3.py
0
    Pass
f8a_worker/schemas.py
0
    Pass
f8a_worker/enums.py
0
    Pass
f8a_worker/workers/finalize.py
0
    Pass
f8a_worker/workers/schemas/languages.py
0
    Pass
f8a_worker/workers/schemas/code_metrics.py
0
    Pass
f8a_worker/workers/schemas/source_licenses.py
0
    Pass
f8a_worker/workers/schemas/github_details.py
0
    Pass
f8a_worker/workers/schemas/security_issues.py
0
    Pass
f8a_worker/workers/schemas/__init__.py
0
    Pass
f8a_worker/workers/schemas/libraries_io.py
0
    Pass
f8a_worker/workers/schemas/metadata.py
0
    Pass
f8a_worker/workers/schemas/binary_data.py
0
    Pass
f8a_worker/workers/schemas/digests.py
0
    Pass
f8a_worker/workers/schemas/crypto_algorithms.py
0
    Pass
f8a_worker/workers/schemas/package_keywords_tagging.py
0
    Pass
f8a_worker/workers/schemas/keywords_tagging.py
0
    Pass
f8a_worker/workers/schemas/dependency_snapshot.py
0
    Pass
f8a_worker/workers/oscryptocatcher.py
0
    Pass
f8a_worker/workers/stackaggregator_v2.py
0
    Pass
f8a_worker/workers/graph_importer.py
0
    Pass
f8a_worker/workers/dependency_parser.py
0
    Pass
f8a_worker/workers/code_metrics.py
0
    Pass
f8a_worker/workers/bigquery_gh.py
0
    Pass
f8a_worker/workers/gh_metadata_result_collector.py
0
    Pass
f8a_worker/workers/bookkeeper.py
0
    Pass
f8a_worker/workers/manifest_keeper.py
0
    Pass
f8a_worker/workers/__init__.py
0
    Pass
f8a_worker/workers/libraries_io.py
0
    Pass
f8a_worker/workers/githuber.py
0
    Pass
f8a_worker/workers/binwalk.py
0
    Pass
f8a_worker/workers/csmock_worker.py
0
    Pass
f8a_worker/workers/linguist.py
0
    Pass
f8a_worker/workers/mercator.py
0
    Pass
f8a_worker/workers/cvedbsync.py
0
    Pass
f8a_worker/workers/digester.py
0
    Pass
f8a_worker/workers/license.py
0
    Pass
f8a_worker/workers/git_stats.py
0
    Pass
f8a_worker/workers/CVEchecker.py
0
    Pass
f8a_worker/workers/init_package_flow.py
0
    Pass
f8a_worker/workers/result_collector.py
0
    Pass
f8a_worker/workers/graphaggregator.py
0
    Pass
f8a_worker/workers/graph_sync.py
0
    Pass
f8a_worker/workers/keywords_summary.py
0
    Pass
f8a_worker/workers/stackaggregator.py
0
    Pass
f8a_worker/workers/keywords_tagging.py
0
    Pass
f8a_worker/workers/init_analysis_flow.py
0
    Pass
f8a_worker/workers/repository_description.py
0
    Pass
f8a_worker/workers/dependency_snapshot.py
0
    Pass
f8a_worker/workers/recommender.py
0
    Pass
f8a_worker/workers/gh_metadata_init.py
0
    Pass
f8a_worker/data_normalizer.py
0
    Pass
f8a_worker/errors.py
0
    Pass
f8a_worker/celery_settings.py
0
    Pass
f8a_worker/defaults.py
0
    Pass
tests/test_data_normalizer.py
0
    Pass
tests/test_schemas.py
0
    Pass
tests/test_process.py
0
    Pass
tests/__init__.py
0
    Pass
tests/data/schemas/generate.py
0
    Pass
tests/test_utils.py
0
    Pass
tests/test_solver.py
0
    Pass
tests/storages/__init__.py
0
    Pass
tests/storages/test_postgres.py
0
    Pass
tests/workers/test_binwalk.py
0
    Pass
tests/workers/test_recurse.py
0
    Pass
tests/workers/__init__.py
0
    Pass
tests/workers/test_oscryptocatcher.py
0
    Pass
tests/workers/_test_csmock.py
0
    Pass
tests/workers/test_licensecheck.py
0
    Pass
tests/workers/test_bigquery_gh.py
0
    Pass
tests/workers/test_linguist.py
0
    Pass
tests/workers/test_libraries_io.py
0
    Pass
tests/workers/test_cvecheck.py
0
    Pass
tests/workers/test_repository_description.py
0
    Pass
tests/workers/test_digester.py
0
    Pass
tests/workers/test_githuber.py
0
    Pass
tests/workers/test_mercator.py
0
    Pass
tests/conftest.py
0
    Pass
hack/queue_conf.py
0
    Pass

----------------------------------------------------
Checking documentation strings in the following files
setup.py
----------------------------------------------------
setup.py
0
    Pass
All checks passed for 168 source files
```