### PR TITLE
[Git.clone()] recreate dir on error if previously existed

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -5,6 +5,7 @@ import pytest
 import subprocess
 
 from f8a_worker.process import Git, IndianaJones
+from f8a_worker.errors import TaskError
 
 
 class TestGit(object):
@@ -22,6 +23,21 @@ class TestGit(object):
         (d / 'foo').touch()
         g = Git.create_git(str(tmpdir))
         g.add_and_commit_everything()
+
+    @pytest.mark.parametrize("url, ok", [
+        ("https://github.com/fabric8-analytics/fabric8-analytics-pgbouncer", True),
+        ("https://github.com/somedummy/somereallydummy", False)
+    ])
+    def test_clone(self, tmpdir, url, ok):
+        """Test Git.clone()."""
+        tmpdir = str(tmpdir)
+        if ok:
+            Git.clone(url, tmpdir)
+            assert (Path(tmpdir) / '.git').is_dir()
+            assert (Path(tmpdir) / 'README.md').is_file()
+        else:
+            with pytest.raises(TaskError):
+                Git.clone(url, tmpdir)
 
 
 class TestIndianaJones(object):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,7 +1,5 @@
 """Tests covering code in process.py."""
 
-import glob
-import os
 from pathlib import Path
 import pytest
 import subprocess
@@ -14,15 +12,14 @@ class TestGit(object):
 
     def test_git_add_and_commit_everything_with_dotgit(self, tmpdir):
         """Test Git.add_and_commit_everything()."""
+        tmpdir = Path(str(tmpdir))
         # if there's a .git file somewhere in the archive, we don't want it to fail adding
         subprocess.check_output(['git', 'init', str(tmpdir)], universal_newlines=True)
-        d = os.path.join(str(tmpdir), 'foo')
-        os.makedirs(d)
-        with open(os.path.join(d, '.git'), 'w') as f:
-            f.write('gitdir: /this/doesnt/exist/hehehe')
+        d = tmpdir / 'foo'
+        d.mkdir(parents=True)
+        (d / '.git').touch()
         # we need at least one normal file for git to commit
-        with open(os.path.join(d, 'foo'), 'w'):
-            pass
+        (d / 'foo').touch()
         g = Git.create_git(str(tmpdir))
         g.add_and_commit_everything()
 


### PR DESCRIPTION
`git clone repo dir/` deletes `dir/` if cloning fails. There's no option to turn this off.
This might confuse caller of the method, who could want to delete the dir itself.
Therefore we recreate the dir/ on error.

Example where this happens is [GitStats._get_log()](https://github.com/fabric8-analytics/fabric8-analytics-worker/blob/master/f8a_worker/workers/git_stats.py#L28)
See https://errortracking.prod-preview.openshift.io/openshift_io/fabric8-analytics-production/issues/705/
which fails with cryptic `No such file or directory: '/tmp/tmpkllc_dvr'` instead of self-explaining `'Unable to clone: https://github.com/babel-plugins/babel-plugin-langpack'`