### PR TITLE
Fix misplaced warning

### DIFF
--- a/f8a_worker/defaults.py
+++ b/f8a_worker/defaults.py
@@ -162,13 +162,14 @@ class F8AConfiguration(object):
         if not cls.LIBRARIES_IO_TOKEN or cls.LIBRARIES_IO_TOKEN == 'not-set':
             raise F8AConfigurationException("LIBRARIES_IO_TOKEN has not been set.")
 
-        # 'no-token' value forces the API call to not use ANY token.
-        # It works, but if abused, they can ban your IP, so use with caution.
         if cls.LIBRARIES_IO_TOKEN != 'no-token':
-            logger.warning("Libraries.io API calls will be without an API key."
-                           "It'll work, but if you're going to analyse more packages,"
-                           "please set the LIBRARIES_IO_TOKEN to your private token.")
             url += '?api_key=' + cls.LIBRARIES_IO_TOKEN
+        else:
+            # 'no-token' value forces the API call to not use ANY token.
+            # It works, but if abused, they can ban your IP, so use with caution.
+            logger.warning("Libraries.io API calls will be without an API key. "
+                           "It'll work, but if you're going to analyse more packages, "
+                           "please set the LIBRARIES_IO_TOKEN to your private token.")
 
         return url
 


### PR DESCRIPTION
It should be shown only when LIBRARIES_IO_TOKEN == 'no-token'