### PR TITLE
NameError: name 'raven' is not defined

### DIFF
--- a/f8a_worker/start.py
+++ b/f8a_worker/start.py
@@ -5,6 +5,7 @@
 import celery
 import os
 from f8a_worker.setup_celery import init_celery, init_selinon
+import raven
 from raven.contrib.celery import register_signal, register_logger_signal
 
 


### PR DESCRIPTION
Fixes issue with `NameError: name 'raven' is not defined`