### PR TITLE
[GithubDependencyTreeTask] maven-dependency-plugin writes errors to stdout, not stderr

### DIFF
--- a/f8a_worker/workers/dependency_parser.py
+++ b/f8a_worker/workers/dependency_parser.py
@@ -42,9 +42,10 @@ class GithubDependencyTreeTask(BaseTask):
                        "-DoutputFile={filename}".format(filename=output_file),
                        "-DappendOutput=true"]
                 timed_cmd = TimedCommand(cmd)
-                status, output, error = timed_cmd.run(timeout=3600)
+                status, output, _ = timed_cmd.run(timeout=3600)
                 if status != 0 or not output_file.is_file():
-                    raise TaskError(error)
+                    # all errors are in stdout, not stderr
+                    raise TaskError(output)
                 with output_file.open() as f:
                     return GithubDependencyTreeTask.parse_maven_dependency_tree(f.readlines())
 


### PR DESCRIPTION
I tried the task on non-maven repo and got empty `TaskError`.