### PR TITLE
Fix another integrity error issue in package level flows

### DIFF
--- a/f8a_worker/workers/init_package_flow.py
+++ b/f8a_worker/workers/init_package_flow.py
@@ -108,6 +108,7 @@ class InitPackageFlow(BaseTask):
 
         # get rid of version if scheduled from the core analyses
         arguments.pop('version', None)
+        arguments.pop('document_id', None)
 
         db = self.storage.session
         try:


### PR DESCRIPTION
`document_id` has a very special meaning in package level flows,
so make sure we don't run around with the one inherited from parent flow.