### PR TITLE
Add support for package-lock.json file for GithubDependencyTreeTask

### DIFF
--- a/f8a_worker/workers/dependency_parser.py
+++ b/f8a_worker/workers/dependency_parser.py
@@ -42,6 +42,10 @@ class GithubDependencyTreeTask(BaseTask):
             repo.reset(revision=github_sha, hard=True)
             with cwd(repo.repo_path):
                 # TODO: Make this task also work for files not present in root directory.
+
+                # First change the package-lock.json to npm-shrinkwrap.json
+                GithubDependencyTreeTask.change_package_lock_to_shrinkwrap()
+
                 if peek(Path.cwd().glob("pom.xml")):
                     return GithubDependencyTreeTask.get_maven_dependencies()
                 elif peek(Path.cwd().glob("npm-shrinkwrap.json")) \
@@ -144,3 +148,17 @@ class GithubDependencyTreeTask(BaseTask):
                                       package=name, version=version))
 
         return set_package_names
+
+    @staticmethod
+    def change_package_lock_to_shrinkwrap():
+        """Rename package-lock.json to npm-shrinkwrap.json.
+
+        For more information about package-lock.json please visit
+        https://docs.npmjs.com/files/package-lock.json
+        """
+        # TODO: Remove this method once mercator has support for package-lock.json
+
+        package_lock_path = Path.cwd() / "package-lock.json"
+
+        if package_lock_path.is_file():
+            package_lock_path.rename("npm-shrinkwrap.json")

--- a/tests/workers/test_github_dependency_tree.py
+++ b/tests/workers/test_github_dependency_tree.py
@@ -10,7 +10,7 @@ class TestGithubDependencyTreeTask(object):
     """Test GithubDependencyTreeTask."""
 
     def test_maven_index_checker_repo(self):
-        """Test GithubDependencyTreeTask."""
+        """Test maven repository with pom.xml."""
         args = {'github_repo': 'https://github.com/fabric8-analytics/maven-index-checker.git',
                 'github_sha': 'de64e1534724e53766dda472e9418350b85a1521',
                 'email_ids': 'dummy'}
@@ -27,3 +27,45 @@ class TestGithubDependencyTreeTask(object):
                                             'maven:com.google.guava:guava:20.0',
                                             'maven:junit:junit:4.10'}
         assert expected_transitive_dependencies.issubset(obtained_dependencies)
+
+    @pytest.mark.usefixtures("npm")
+    def test_npm_repo_with_package_lock(self):
+        """Test npm repository with package-lock.json."""
+        args = {
+            'github_repo': 'https://github.com/abs51295/node-js-sample',
+            'github_sha': '01fe0580c697d34118baef3b9e5fe3edf64bc4e3',
+            'email_ids': 'dummy'
+        }
+        task = GithubDependencyTreeTask.create_test_instance(task_name='dependency_tree')
+        results = task.execute(args)
+        assert isinstance(results, dict)
+        assert set(results.keys()) == {'dependencies', 'github_repo', 'github_sha', 'email_ids'}
+        obtained_dependencies = set(results['dependencies'])
+        expected_dependencies = {'npm:express:4.16.3', 'npm:ipaddr.js:1.6.0',
+                                 'npm:finalhandler:1.1.1', 'npm:inherits:2.0.3',
+                                 'npm:content-disposition:0.5.2', 'npm:proxy-addr:2.0.3',
+                                 'npm:ms:2.0.0', 'npm:etag:1.8.1',
+                                 'npm:utils-merge:1.0.1', 'npm:qs:6.5.1',
+                                 'npm:merge-descriptors:1.0.1',
+                                 'npm:depd:1.1.1', 'npm:debug:2.6.9',
+                                 'npm:cookie-signature:1.0.6',
+                                 'npm:bytes:3.0.0', 'npm:mime-types:2.1.18',
+                                 'npm:ee-first:1.1.1', 'npm:raw-body:2.3.2',
+                                 'npm:setprototypeof:1.0.3', 'npm:parseurl:1.3.2',
+                                 'npm:negotiator:0.6.1', 'npm:serve-static:1.13.2',
+                                 'npm:path-to-regexp:0.1.7', 'npm:media-typer:0.3.0',
+                                 'npm:iconv-lite:0.4.19', 'npm:setprototypeof:1.1.0',
+                                 'npm:forwarded:0.1.2', 'npm:statuses:1.4.0',
+                                 'npm:content-type:1.0.4', 'npm:fresh:0.5.2',
+                                 'npm:array-flatten:1.1.1', 'npm:type-is:1.6.16',
+                                 'npm:on-finished:2.3.0', 'npm:http-errors:1.6.2',
+                                 'npm:accepts:1.3.5', 'npm:vary:1.1.2',
+                                 'npm:unpipe:1.0.0', 'npm:safe-buffer:5.1.1',
+                                 'npm:destroy:1.0.4', 'npm:encodeurl:1.0.2',
+                                 'npm:mime-db:1.33.0', 'npm:body-parser:1.18.2',
+                                 'npm:range-parser:1.2.0', 'npm:methods:1.1.2',
+                                 'npm:send:0.16.2', 'npm:depd:1.1.2',
+                                 'npm:cookie:0.3.1', 'npm:http-errors:1.6.3',
+                                 'npm:mime:1.4.1', 'npm:escape-html:1.0.3'}
+
+        assert obtained_dependencies == expected_dependencies


### PR DESCRIPTION
- Currently, mercator only supports npm-shrinkwrap.json and hence we need a hack to support package-lock.json as of now.
- Need to revert this once mercator supports package-lock.json.

Signed-off-by: abs51295 <aagams68@gmail.com>