### PR TITLE
Migrate to pip 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.devshift.net/fabric8-analytics/f8a-worker-base:819a389
+FROM registry.devshift.net/fabric8-analytics/f8a-worker-base:add2858
 
 ENV LANG=en_US.UTF-8 \
     # place where to download & unpack artifacts

--- a/f8a_worker/manifests.py
+++ b/f8a_worker/manifests.py
@@ -3,8 +3,8 @@
 from io import StringIO
 import json
 from lxml import etree
-from pip.req import parse_requirements
-from pip.exceptions import RequirementsFileParseError
+from pip._internal.req.req_file import parse_requirements
+from pip._internal.exceptions import RequirementsFileParseError
 import yaml
 
 _registered_manifest_descriptors = []

--- a/f8a_worker/solver.py
+++ b/f8a_worker/solver.py
@@ -7,7 +7,7 @@ from functools import cmp_to_key
 import logging
 from lxml import etree
 from operator import itemgetter
-from pip.req.req_file import parse_requirements
+from pip._internal.req.req_file import parse_requirements
 from pip._vendor.packaging.specifiers import _version_split
 import re
 from requests import get

--- a/hack/install_tagger.sh
+++ b/hack/install_tagger.sh
@@ -6,8 +6,6 @@ set -e
 
 F8A_TAGGER_COMMIT=3eac4b7
 
-# tagger uses python wrapper above libarchive so install it explicitly
-yum install -y libarchive
 pip3 install --upgrade git+https://github.com/fabric8-analytics/fabric8-analytics-tagger@${F8A_TAGGER_COMMIT}
 # Install external resources needed for automated tagging.
 python3 -c 'import f8a_tagger; f8a_tagger.prepare()'


### PR DESCRIPTION
Using Pip's internal API is exactly what we SHOULDN'T be doing, but we also don't want to reimplement the logic on our own. We want to parse requirement.txt files exactly as the native tool, Pip, would parse them.

We will see how this goes. 