### PR TITLE
Add support for Go ecosystem for GithubDependencyTreeTask

### DIFF
--- a/f8a_worker/dispatcher/flows/osioAnalysisFlow.yml
+++ b/f8a_worker/dispatcher/flows/osioAnalysisFlow.yml
@@ -11,6 +11,11 @@
           to: 'dependencyIngestFlow'
         - from: 'dependencyIngestFlow'
           to: 'ReportGenerationTask'
+      failures:
+        - nodes:
+            - 'dependencyIngestFlow'
+          fallback:
+            - 'ReportGenerationTask'
 
     - name: 'dependencyIngestFlow'
       queue: '{DEPLOYMENT_PREFIX}_api_dependencyIngestFlow_v0'

--- a/f8a_worker/workers/dependency_parser.py
+++ b/f8a_worker/workers/dependency_parser.py
@@ -1,6 +1,7 @@
-"""Output: TBD."""
+"""Output: List of direct and indirect dependencies."""
 
 import re
+import anymarkup
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -35,7 +36,11 @@ class GithubDependencyTreeTask(BaseTask):
     def extract_dependencies(github_repo, github_sha):
         """Extract the dependencies information.
 
-        Currently assuming repository is maven/npm repository.
+        Currently assuming repository is maven/npm/python repository.
+
+        :param github_repo: repository url
+        :param github_sha: commit hash
+        :return: set of direct (and indirect) dependencies
         """
         with TemporaryDirectory() as workdir:
             repo = Git.clone(url=github_repo, path=workdir, timeout=3600)
@@ -51,14 +56,21 @@ class GithubDependencyTreeTask(BaseTask):
                 elif peek(Path.cwd().glob("npm-shrinkwrap.json")) \
                         or peek(Path.cwd().glob("package.json")):
                     return GithubDependencyTreeTask.get_npm_dependencies(repo.repo_path)
+                elif peek(Path.cwd().glob("requirements.txt")):
+                    return GithubDependencyTreeTask.get_python_dependencies(repo.repo_path)
+                elif peek(Path.cwd().glob("glide.lock")):
+                    return GithubDependencyTreeTask.get_go_glide_dependencies(repo.repo_path)
+                elif peek(Path.cwd().glob("Gopkg.lock")):
+                    return GithubDependencyTreeTask.get_go_pkg_dependencies()
                 else:
-                    raise TaskError("Please provide maven or npm repository for scanning!")
+                    raise TaskError("Please provide maven or npm or "
+                                    "python repository for scanning!")
 
     @staticmethod
     def get_maven_dependencies():
         """Get direct and indirect dependencies from pom.xml by using maven dependency tree plugin.
 
-        :return: a list of direct and indirect dependencies
+        :return: set of direct and indirect dependencies
         """
         output_file = Path.cwd() / "dependency-tree.txt"
         cmd = ["mvn", "org.apache.maven.plugins:maven-dependency-plugin:3.0.2:tree",
@@ -79,6 +91,9 @@ class GithubDependencyTreeTask(BaseTask):
 
         For available representations of dependency tree see
         http://maven.apache.org/plugins/maven-dependency-plugin/tree-mojo.html#outputType
+
+        :param dependency_tree: DOT representation of maven dependency tree
+        :return: set of direct and indirect dependencies
         """
         dot_file_parser_regex = re.compile('"(.*?)"')
         set_pom_names = set()
@@ -107,7 +122,7 @@ class GithubDependencyTreeTask(BaseTask):
         and provides only the list of direct dependencies.
 
         :param path: path to run the mercator
-        :return: list of direct (and indirect) dependencies
+        :return: set of direct (and indirect) dependencies
         """
         mercator_output = cls._mercator.run_mercator(arguments={"ecosystem": "npm"},
                                                      cache_path=path,
@@ -145,6 +160,103 @@ class GithubDependencyTreeTask(BaseTask):
             for dependency in all_dependencies:
                 name, version = dependency.split()
                 set_package_names.add("{ecosystem}:{package}:{version}".format(ecosystem="npm",
+                                      package=name, version=version))
+
+        return set_package_names
+
+    @classmethod
+    def get_python_dependencies(cls, path):
+        """Get a list of direct and indirect dependencies from requirements.txt.
+
+        To get a list of direct and transitive dependencies the requirements.txt
+        file has to be generated through `pip-compile` else only direct dependencies
+        can be extracted.
+
+        :param path: path to run the mercator
+        :return: set of direct (and indirect) dependencies
+        """
+        mercator_output = cls._mercator.run_mercator(arguments={"ecosystem": "pypi"},
+                                                     cache_path=path,
+                                                     resolve_poms=False)
+
+        set_package_names = set()
+        mercator_output_details = mercator_output['details'][0]
+        dependencies = mercator_output_details.get('dependencies', [])
+        for dependency in dependencies:
+            name, version = dependency.split("==")
+            set_package_names.add("{ecosystem}:{package}:{version}".format(ecosystem="pypi",
+                                  package=name, version=version))
+
+        return set_package_names
+
+    @classmethod
+    def get_go_glide_dependencies(cls, path):
+        """Get all direct and transitive dependencies by parsing glide.lock.
+
+        :param path: path to run the mercator
+        :return: set of direct and indirect dependencies
+        """
+        mercator_output = cls._mercator.run_mercator(arguments={"ecosystem": "go"},
+                                                     cache_path=path,
+                                                     resolve_poms=False)
+
+        set_package_names = set()
+
+        mercator_output_details = mercator_output['details'][0]
+        dependency_tree_lock = mercator_output_details \
+            .get('_dependency_tree_lock')
+
+        dependencies = dependency_tree_lock.get('dependencies')
+
+        for dependency in dependencies:
+            sub_packages = dependency.get('subpackages')
+            name = dependency.get('name')
+            version = dependency.get('version')
+
+            if sub_packages:
+                for sub_package in sub_packages:
+                    # Ignore sub-packages like '.', '..', '...' etc.
+                    if sub_package != len(sub_package) * '.':
+                        # We need to come up with a unified format of how sub-packages are presented.
+                        sub_package_name = name + '/{}'.format(sub_package)
+                        set_package_names.add("{ecosystem}:{package}:{version}".format(ecosystem="go",
+                                              package=sub_package_name, version=version))
+                    else:
+                        set_package_names.add("{ecosystem}:{package}:{version}".format(ecosystem="go",
+                                              package=name, version=version))
+            else:
+                set_package_names.add("{ecosystem}:{package}:{version}".format(ecosystem="go",
+                                      package=name, version=version))
+
+        return set_package_names
+
+    @staticmethod
+    def get_go_pkg_dependencies():
+        """Get all direct and indirect dependencies by parsing Gopkg.lock.
+        
+        :return: set of direct and indirect dependencies
+        """
+        # TODO: Run mercator instead of this custom parsing logic, once mercator supports this.
+        set_package_names = set()
+        lock_file_contents = anymarkup.parse_file('Gopkg.lock', format='toml')
+        packages = lock_file_contents.get('projects')
+        for package in packages:
+            name = package.get('name')
+            sub_packages = package.get('packages')
+            version = package.get('revision')
+
+            if sub_packages:
+                for sub_package in sub_packages:
+                    # Ignore sub-packages like '.', '..', '...' etc.
+                    if sub_package != len(sub_package) * '.':
+                        sub_package_name = name + '/{}'.format(sub_package)
+                        set_package_names.add("{ecosystem}:{package}:{version}".format(ecosystem="go",
+                                              package=sub_package_name, version=version))
+                    else:
+                        set_package_names.add("{ecosystem}:{package}:{version}".format(ecosystem="go",
+                                              package=name, version=version))
+            else:
+                set_package_names.add("{ecosystem}:{package}:{version}".format(ecosystem="go",
                                       package=name, version=version))
 
         return set_package_names

--- a/tests/workers/test_github_dependency_tree.py
+++ b/tests/workers/test_github_dependency_tree.py
@@ -28,6 +28,28 @@ class TestGithubDependencyTreeTask(object):
                                             'maven:junit:junit:4.10'}
         assert expected_transitive_dependencies.issubset(obtained_dependencies)
 
+    @pytest.mark.usefixtures("pypi")
+    def test_python_requirements_txt(self):
+        """Test python repository with requirements.txt."""
+        args = {
+            "github_repo": "https://github.com/abs51295/status-api",
+            "github_sha": "229f47d3a634ae6a6e660228c7ceaeb70bb4cfaa",
+            "email_ids": "dummy"
+        }
+        task = GithubDependencyTreeTask.create_test_instance(task_name='dependency_tree')
+        results = task.execute(args)
+        assert isinstance(results, dict)
+        assert set(results.keys()) == {'dependencies', 'github_repo', 'github_sha', 'email_ids'}
+        obtained_dependencies = set(results['dependencies'])
+        expected_dependencies = {'pypi:py-zabbix:1.1.0', 'pypi:uwsgi:2.0.15',
+                                 'pypi:werkzeug:0.14.1', 'pypi:jinja2:2.10',
+                                 'pypi:flask:0.12.1', 'pypi:click:6.7',
+                                 'pypi:six:1.11.0', 'pypi:aniso8601:3.0.0',
+                                 'pypi:itsdangerous:0.24', 'pypi:markupsafe:1.0',
+                                 'pypi:flask-restful:0.3.5', 'pypi:pytz:2018.4'}
+
+        assert obtained_dependencies == expected_dependencies
+
     @pytest.mark.usefixtures("npm")
     def test_npm_repo_with_package_lock(self):
         """Test npm repository with package-lock.json."""


### PR DESCRIPTION
- Parse Gopkg.lock file via anymarkup to gather all direct and transitive dependencies along with their versions.
- Parse glide.lock file via mercator to gather all direct and transitive dependencies along with their versions.