### PR TITLE
Deploy on RHEL based container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,3 @@ target/
 *.swo
 *.swp
 .idea/*
-
-# RHEL Dockerfile generated from a template
-Dockerfile.rhel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.devshift.net/fabric8-analytics/f8a-worker-base:add2858
+FROM registry.devshift.net/fabric8-analytics/f8a-worker-base:bfb2ff4
 
 ENV LANG=en_US.UTF-8 \
     # place where to download & unpack artifacts

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM __REGISTRY__/fabric8-analytics/f8a-worker-base:819a389
+FROM prod.registry.devshift.net/osio-prod/fabric8-analytics/f8a-worker-base:bfb2ff4
 
 ENV LANG=en_US.UTF-8 \
     # place where to download & unpack artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
+REGISTRY?=registry.devshift.net
+REPOSITORY?=bayesian/cucos-worker
+DEFAULT_TAG=latest
+
 ifeq ($(TARGET), rhel)
     DOCKERFILE := Dockerfile.rhel
 else
     DOCKERFILE := Dockerfile
 endif
-
-REPOSITORY?=bayesian/cucos-worker
-DEFAULT_TAG=latest
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,9 @@
 ifeq ($(TARGET), rhel)
     DOCKERFILE := Dockerfile.rhel
-
-    ifndef DOCKER_REGISTRY
-        $(error DOCKER_REGISTRY is not set)
-    endif
-
-    REGISTRY := $(DOCKER_REGISTRY)
 else
     DOCKERFILE := Dockerfile
-    REGISTRY?=registry.devshift.net
 endif
+
 REPOSITORY?=bayesian/cucos-worker
 DEFAULT_TAG=latest
 
@@ -18,8 +12,6 @@ DEFAULT_TAG=latest
 all: fast-docker-build
 
 docker-build:
-	cp Dockerfile.rhel.template Dockerfile.rhel
-	sed -i "s/__REGISTRY__/$(REGISTRY)/g" Dockerfile.rhel
 	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(REPOSITORY):$(DEFAULT_TAG)
 
@@ -27,8 +19,6 @@ docker-build-tests: docker-build
 	docker build --no-cache -t worker-tests -f Dockerfile.tests .
 
 fast-docker-build:
-	cp Dockerfile.rhel.template Dockerfile.rhel
-	sed -i "s/__REGISTRY__/$(REGISTRY)/g" Dockerfile.rhel
 	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(REPOSITORY):$(DEFAULT_TAG)
 

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -4,6 +4,8 @@ set -ex
 
 . cico_setup.sh
 
+docker_login
+
 build_image
 
 IMAGE_NAME=$(make get-image-name) ./runtest.sh

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -4,6 +4,8 @@ set -ex
 
 . cico_setup.sh
 
+docker_login
+
 build_image
 
 IMAGE_NAME=$(make get-image-name) ./runtest.sh

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -2,12 +2,6 @@
 
 REGISTRY="push.registry.devshift.net"
 
-if [ "$TARGET" = "rhel" ]; then
-    IMAGE_URL=${REGISTRY}/osio-prod/${image_repository}
-else
-    IMAGE_URL=${REGISTRY}/${image_repository}
-fi
-
 load_jenkins_vars() {
     if [ -e "jenkins-env" ]; then
         cat jenkins-env \
@@ -52,6 +46,12 @@ push_image() {
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
     short_commit=$(git rev-parse --short=7 HEAD)
+
+    if [ "$TARGET" = "rhel" ]; then
+        IMAGE_URL="${REGISTRY}/osio-prod/${image_repository}"
+    else
+        IMAGE_URL="${REGISTRY}/${image_repository}"
+    fi
 
     if [ -n "${ghprbPullId}" ]; then
         # PR build

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -ex
 
+REGISTRY="push.registry.devshift.net"
+
+if [ "$TARGET" = "rhel" ]; then
+    IMAGE_URL=${REGISTRY}/osio-prod/${image_repository}
+else
+    IMAGE_URL=${REGISTRY}/${image_repository}
+fi
+
 load_jenkins_vars() {
     if [ -e "jenkins-env" ]; then
         cat jenkins-env \
@@ -7,6 +15,15 @@ load_jenkins_vars() {
           | sed 's/^/export /g' \
           > ~/.jenkins-env
         source ~/.jenkins-env
+    fi
+}
+
+docker_login() {
+    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
+        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+    else
+        echo "Could not login, missing credentials for the registry"
+        exit 1
     fi
 }
 
@@ -32,41 +49,19 @@ push_image() {
     local image_name
     local image_repository
     local short_commit
-    local push_registry
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
     short_commit=$(git rev-parse --short=7 HEAD)
 
-    if [ "$TARGET" = "rhel" ]; then
-        if [ -z "${DOCKER_REGISTRY}" ]; then
-            echo "DOCKER_REGISTRY must be defined for TARGET=rhel" >&2
-            exit 1
-        fi
-
-        push_registry="${DOCKER_REGISTRY}"
-    else
-        push_registry="push.registry.devshift.net"
-    fi
-
-    if [ "$TARGET" != "rhel" ]; then
-        # login first
-        if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-            docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
-        else
-            echo "Could not login, missing credentials for the registry"
-            exit 1
-        fi
-    fi
-
     if [ -n "${ghprbPullId}" ]; then
         # PR build
         pr_id="SNAPSHOT-PR-${ghprbPullId}"
-        tag_push ${push_registry}/${image_repository}:${pr_id} ${image_name}
-        tag_push ${push_registry}/${image_repository}:${pr_id}-${short_commit} ${image_name}
+        tag_push ${IMAGE_URL}:${pr_id} ${image_name}
+        tag_push ${IMAGE_URL}:${pr_id}-${short_commit} ${image_name}
     else
         # master branch build
-        tag_push ${push_registry}/${image_repository}:latest ${image_name}
-        tag_push ${push_registry}/${image_repository}:${short_commit} ${image_name}
+        tag_push ${IMAGE_URL}:latest ${image_name}
+        tag_push ${IMAGE_URL}:${short_commit} ${image_name}
     fi
 
     echo 'CICO: Image pushed, ready to update deployed app'


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
into staging.

This PR includes a new RHEL based dockerfile for the deployment of the service.
This dockerfile will be built when this variable is set: TARGET=rhel. The build
scripts have been adapted to take this into consideration, and to push the image
to different namespaces if the TARGET is rhel or not.

Currently the deployment builds happen on empty baremetal machines. The build
script will be executed a second time to build and push the deployment file if
TARGET=rhel, so some changes in the build script are to ensure that it will work
if executed a second time.