### PR TITLE
Create non-error exception for further Sentry integration

### DIFF
--- a/f8a_worker/errors.py
+++ b/f8a_worker/errors.py
@@ -6,8 +6,18 @@ class TaskError(Exception):
     """There was an error during task execution."""
 
 
-class NonCriticalTaskError(TaskError):
-    """There was an error during task execution."""
+class NotABugTaskError(TaskError):
+    """Task error, but not a bug in the code.
+
+    This exception will be ignored by Sentry.
+    """
+
+
+class NotABugFatalTaskError(FatalTaskError):
+    """Task error, but not a bug in the code. Retry won't help.
+
+    This exception will be ignored by Sentry.
+    """
 
 
 class F8AConfigurationException(Exception):

--- a/f8a_worker/errors.py
+++ b/f8a_worker/errors.py
@@ -6,6 +6,10 @@ class TaskError(Exception):
     """There was an error during task execution."""
 
 
+class NonCriticalTaskError(TaskError):
+    """There was an error during task execution."""
+
+
 class F8AConfigurationException(Exception):
     """There was an error during handling configuration."""
 

--- a/f8a_worker/start.py
+++ b/f8a_worker/start.py
@@ -18,6 +18,9 @@ class SentryCelery(celery.Celery):
         client = raven.Client(dsn)
         register_logger_signal(client)
         register_signal(client)
+        client.ignore_exceptions = [
+            "f8a_worker.errors.NonCriticalTaskError"
+        ]
 
 
 app = SentryCelery('tasks')

--- a/f8a_worker/start.py
+++ b/f8a_worker/start.py
@@ -19,7 +19,8 @@ class SentryCelery(celery.Celery):
         register_logger_signal(client)
         register_signal(client)
         client.ignore_exceptions = [
-            "f8a_worker.errors.NonCriticalTaskError"
+            "f8a_worker.errors.NotABugFatalTaskError",
+            "f8a_worker.errors.NotABugTaskError"
         ]
 
 


### PR DESCRIPTION
This PR is creating an exception which is inherited from `TaskError`. It means that once you throw this exception flow will end, but it will be ignored by a Sentry.