### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.devshift.net/fabric8-analytics/f8a-worker-base:0bcf081
+FROM quay.io/openshiftio/fabric8-analytics-f8a-worker-base:80aefc1
 
 ENV LANG=en_US.UTF-8 \
     # place where to download & unpack artifacts

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM quay.io/openshiftio/rhel-fabric8-analytics-f8a-worker-base:0bcf081
+FROM quay.io/openshiftio/rhel-fabric8-analytics-f8a-worker-base:80aefc1
 
 ENV LANG=en_US.UTF-8 \
     # place where to download & unpack artifacts

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/fabric8-analytics/f8a-worker-base:0bcf081
+FROM quay.io/openshiftio/rhel-fabric8-analytics-f8a-worker-base:0bcf081
 
 ENV LANG=en_US.UTF-8 \
     # place where to download & unpack artifacts

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,5 +1,4 @@
-FROM bayesian/cucos-worker
-
+FROM worker-tests
 ENV PYTHONDONTWRITEBYTECODE 1
 
 COPY . /f8a_worker

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-REGISTRY?=registry.devshift.net
-REPOSITORY?=bayesian/cucos-worker
+REGISTRY?=quay.io
 DEFAULT_TAG=latest
 
 ifeq ($(TARGET), rhel)
     DOCKERFILE := Dockerfile.rhel
+	REPOSITORY ?= openshiftio/rhel-bayesian-cucos-worker
 else
     DOCKERFILE := Dockerfile
+	REPOSITORY ?= openshiftio/bayesian-cucos-worker
 endif
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,8 @@ test: fast-docker-build-tests
 get-image-name:
 	@echo $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG)
 
+get-image-name-base:
+	@echo $(REGISTRY)/$(REPOSITORY)
+
 get-image-repository:
 	@echo $(REPOSITORY)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 REGISTRY?=quay.io
 DEFAULT_TAG=latest
+TESTS_IMAGE=worker-tests
 
 ifeq ($(TARGET), rhel)
     DOCKERFILE := Dockerfile.rhel
@@ -15,17 +16,17 @@ all: fast-docker-build
 
 docker-build:
 	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
-	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(REPOSITORY):$(DEFAULT_TAG)
+	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(TESTS_IMAGE):$(DEFAULT_TAG)
 
 docker-build-tests: docker-build
-	docker build --no-cache -t worker-tests -f Dockerfile.tests .
+	docker build --no-cache -t $(TESTS_IMAGE) -f Dockerfile.tests .
 
 fast-docker-build:
 	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
-	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(REPOSITORY):$(DEFAULT_TAG)
+	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(TESTS_IMAGE):$(DEFAULT_TAG)
 
 fast-docker-build-tests: fast-docker-build
-	docker build -t worker-tests -f Dockerfile.tests .
+	docker build -t $(TESTS_IMAGE) -f Dockerfile.tests .
 
 test: fast-docker-build-tests
 	./runtest.sh

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -47,11 +47,9 @@ tag_push() {
 
 push_image() {
     local image_name
-    local image_repository
     local short_commit
 
-    image_name=$(make get-image-name)
-    image_repository=$(make get-image-repository)
+    image_name=$(make get-image-name-base)
     short_commit=$(git rev-parse --short=$DEVSHIFT_TAG_LEN HEAD)
 
     if [ -n "${ghprbPullId}" ]; then

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,20 +1,26 @@
 #!/bin/bash -ex
 
-REGISTRY="push.registry.devshift.net"
+REGISTRY="quay.io"
 
 load_jenkins_vars() {
-    if [ -e "jenkins-env" ]; then
-        <jenkins-env \
-          grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-          | sed 's/^/export /g' \
-          > ~/.jenkins-env
-        source ~/.jenkins-env
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json \
+                DEVSHIFT_TAG_LEN \
+                QUAY_USERNAME \
+                QUAY_PASSWORD \
+                JENKINS_URL \
+                GIT_BRANCH \
+                GIT_COMMIT \
+                BUILD_NUMBER \
+                ghprbSourceBranch \
+                ghprbActualCommit \
+                BUILD_URL \
+                ghprbPullId)"
     fi
 }
-
 docker_login() {
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u "${DEVSHIFT_USERNAME}" -p "${DEVSHIFT_PASSWORD}" "${REGISTRY}"
+    if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+        docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" "${REGISTRY}"
     else
         echo "Could not login, missing credentials for the registry"
         exit 1
@@ -43,25 +49,20 @@ push_image() {
     local image_name
     local image_repository
     local short_commit
+
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
-    short_commit=$(git rev-parse --short=7 HEAD)
-
-    if [ "$TARGET" = "rhel" ]; then
-        IMAGE_URL="${REGISTRY}/osio-prod/${image_repository}"
-    else
-        IMAGE_URL="${REGISTRY}/${image_repository}"
-    fi
+    short_commit=$(git rev-parse --short=$DEVSHIFT_TAG_LEN HEAD)
 
     if [ -n "${ghprbPullId}" ]; then
         # PR build
         pr_id="SNAPSHOT-PR-${ghprbPullId}"
-        tag_push "${IMAGE_URL}:${pr_id}" "${image_name}"
-        tag_push "${IMAGE_URL}:${pr_id}-${short_commit}" "${image_name}"
+        tag_push "${image_name}:${pr_id}" "${image_name}"
+        tag_push "${image_name}:${pr_id}-${short_commit}" "${image_name}"
     else
         # master branch build
-        tag_push "${IMAGE_URL}:latest" "${image_name}"
-        tag_push "${IMAGE_URL}:${short_commit}" "${image_name}"
+        tag_push "${image_name}:latest" "${image_name}"
+        tag_push "${image_name}:${short_commit}" "${image_name}"
     fi
 
     echo 'CICO: Image pushed, ready to update deployed app'

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -49,7 +49,7 @@ objects:
           - name: SENTRY_DSN
             valueFrom:
               secretKeyRef:
-                name: worker 
+                name: worker
                 key: sentry_dsn
           - name: POSTGRESQL_DATABASE
             valueFrom:
@@ -208,13 +208,13 @@ parameters:
   displayName: Docker registry
   required: true
   name: DOCKER_REGISTRY
-  value: "registry.devshift.net"
+  value: "quay.io"
 
 - description: Docker image to use
   displayName: Docker image
   required: true
   name: DOCKER_IMAGE
-  value: "bayesian/cucos-worker"
+  value: "openshiftio/rhel-bayesian-cucos-worker"
 
 - description: Image tag
   displayName: Image tag
@@ -252,7 +252,7 @@ parameters:
   name: MEMORY_LIMIT
   value: "1536Mi"
 
-- description: Sentry DSN 
+- description: Sentry DSN
   displayName: Sentry DSN
   required: false
   name: SENTRY_DSN


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should
  not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo
to change the staging url from devshift to quay. The PR to the saas
repo should be merged before this one.
https://github.com/openshiftio/saas-analytics/pull/417