### PR TITLE
Notify gemini about missing lock file

### DIFF
--- a/f8a_worker/workers/dependency_parser.py
+++ b/f8a_worker/workers/dependency_parser.py
@@ -29,8 +29,14 @@ class GithubDependencyTreeTask(BaseTask):
         self._strict_assert(arguments.get('email_ids'))
         github_repo = arguments.get('github_repo')
         github_sha = arguments.get('github_sha')
-        dependencies = list(GithubDependencyTreeTask.extract_dependencies(
-            github_repo=github_repo, github_sha=github_sha))
+        try:
+            dependencies = list(GithubDependencyTreeTask.extract_dependencies(
+                github_repo=github_repo, github_sha=github_sha))
+        except TypeError:
+            return {"github_repo": github_repo, "dependencies": [],
+                    "github_sha": github_sha, "email_ids": arguments.get('email_ids'),
+                    "lock_file_absent": True, "message": "Lock file not found"}
+
         return {"dependencies": dependencies, "github_repo": github_repo,
                 "github_sha": github_sha, "email_ids": arguments.get('email_ids')}
 
@@ -83,8 +89,7 @@ class GithubDependencyTreeTask(BaseTask):
                 elif peek(Path.cwd().glob("Gopkg.lock")):
                     return GithubDependencyTreeTask.get_go_pkg_dependencies()
                 else:
-                    raise TaskError("Please provide maven or npm or "
-                                    "python or Go repository for scanning!")
+                    return None
 
     @staticmethod
     def get_maven_dependencies(user_flow):

--- a/f8a_worker/workers/report_generation.py
+++ b/f8a_worker/workers/report_generation.py
@@ -105,9 +105,20 @@ class ReportGenerationTask(BaseTask):
         :return: {}, results
         """
         self.log.debug("Arguments passed from flow: {}".format(arguments))
-        self._strict_assert(arguments.get('dependencies'))
+
         self._strict_assert(arguments.get('github_sha'))
         self._strict_assert(arguments.get('github_repo'))
+        arguments.update({"external_request_id": arguments.get('github_sha')})
+
+        if arguments.get('lock_file_absent'):
+            return {"dependencies": [],
+                    "scanned_at": strftime("%Y-%m-%dT%H:%M:%S", gmtime()),
+                    "git_url": arguments.get('github_repo'),
+                    "lock_file_absent": arguments.get('lock_file_absent'),
+                    "message": arguments.get('message')}
+
+        # Strict assert dependencies when we are sure that lock file is present.
+        self._strict_assert(arguments.get('dependencies'))
         resolved_dependencies = arguments.get('dependencies')
         self.log.debug("Resolved dependencies are: {}".format(resolved_dependencies))
         dependency_list = self._get_dependency_data(dependencies=resolved_dependencies)

--- a/f8a_worker/workers/unknown_dep_fetcher.py
+++ b/f8a_worker/workers/unknown_dep_fetcher.py
@@ -57,6 +57,11 @@ class UnknownDependencyFetcherTask(BaseTask):
         :return: {}, results
         """
         self.log.debug("Arguments passed from GithubDependencyTreeTask: {}".format(arguments))
+
+        if arguments.get("lock_file_absent"):
+            return {"lock_file_absent": arguments.get('lock_file_absent'),
+                    "result": [], "message": arguments.get('message')}
+
         self._strict_assert(arguments.get('dependencies'))
         result = self.get_dependency_data(arguments.get('dependencies'))
         return {"result": result}

--- a/tests/workers/test_github_dependency_tree.py
+++ b/tests/workers/test_github_dependency_tree.py
@@ -91,3 +91,20 @@ class TestGithubDependencyTreeTask(object):
                                  'npm:mime:1.4.1', 'npm:escape-html:1.0.3'}
 
         assert obtained_dependencies == expected_dependencies
+
+    def test_repo_with_no_lockfile(self):
+        """Test repository with no lock file present."""
+        args = {'github_repo': 'https://github.com/abs51295/code2vec',
+                'github_sha': '02ec2d941f8dd1a26c1469aaaf4849a3a803423b',
+                'email_ids': 'dummy'}
+        task = GithubDependencyTreeTask.create_test_instance(task_name='dependency_tree')
+        results = task.execute(args)
+
+        assert isinstance(results, dict)
+        assert set(results.keys()) == {'dependencies', 'github_repo', 'github_sha',
+                                       'email_ids', 'lock_file_absent', 'message'}
+
+        obtained_dependencies = set(results['dependencies'])
+        assert obtained_dependencies == set()
+        lock_file_absent = results['lock_file_absent']
+        assert lock_file_absent is True


### PR DESCRIPTION
- Adds a flag 'lock_file_absent' and returns a json response instead of raising a TaskError if lock file is absent in the repository during scanning.