### PR TITLE
Fix mercator output for certain shrinkwrap files

### DIFF
--- a/f8a_worker/data_normalizer.py
+++ b/f8a_worker/data_normalizer.py
@@ -270,7 +270,11 @@ class DataNormalizer(object):
             lockfile['version'] = lockfile.pop('npm-shrinkwrap-version', "")
             lockfile['runtime'] = data.get('_nodeVersion', "")
             lockfile['dependencies'] = dependencies
-            lockfile.pop('node-version', None)
+
+            # Drop rest of the unknown/unwanted keys
+            for key in list(lockfile.keys()):
+                if key not in ('dependencies', 'version', 'runtime', 'name', 'hash', 'updated'):
+                    lockfile.pop(key)
 
         base['_tests_implemented'] = self._are_tests_implemented(base)
         return base

--- a/tests/data/dataNormalizer/npm-with-shrinkwrap-json-from-mercator
+++ b/tests/data/dataNormalizer/npm-with-shrinkwrap-json-from-mercator
@@ -52,7 +52,8 @@
             }
          },
          "name":"tar",
-         "version":"2.2.1"
+         "version":"2.2.1",
+         "lockfileVersion": 1
       },
       "_from":"tar@latest",
       "_id":"tar@2.2.1",


### PR DESCRIPTION
Fixes:
{'version': '', 'runtime': '', 'name': '@hint/hint-no-broken-links',
'lockfileVersion': 1, 'dependencies': []}
is not valid under any of the given schemas