### PR TITLE
Fix bucket name for S3IssuesPRs storage

### DIFF
--- a/f8a_worker/storages/s3.py
+++ b/f8a_worker/storages/s3.py
@@ -34,8 +34,8 @@ class AmazonS3(DataStorage):
         self._s3 = None
 
         self.region_name = configuration.AWS_S3_REGION or region_name or self._DEFAULT_REGION_NAME
-        self.bucket_name = bucket_name or self._DEFAULT_BUCKET_NAME
-        self.bucket_name = self.bucket_name.format(**os.environ)
+        bucket_name = bucket_name or self._DEFAULT_BUCKET_NAME
+        self.bucket_name = bucket_name.format(**os.environ)
         self._aws_access_key_id = configuration.AWS_S3_ACCESS_KEY_ID or aws_access_key_id
         self._aws_secret_access_key = \
             configuration.AWS_S3_SECRET_ACCESS_KEY or aws_secret_access_key

--- a/f8a_worker/storages/s3_gocveartifact.py
+++ b/f8a_worker/storages/s3_gocveartifact.py
@@ -9,6 +9,20 @@ logger = logging.getLogger(__name__)
 class S3IssuesPRs(AmazonS3):
     """S3 storage for repository description."""
 
+    @property
+    def bucket_name(self):
+        """Get bucket name."""
+        return self._bucket_name
+
+    @bucket_name.setter
+    def bucket_name(self, bucket_name):
+        """Set bucket name, but make it all lower case."""
+        # Since March 1, 2018, Amazon S3 no longer supports creating bucket names
+        # that contain uppercase letters or underscores.
+        # Docs: https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+        # TODO: remove once deployment prefix in staging (STAGE-) is fixed and data is migrated
+        self._bucket_name = bucket_name.lower()
+
     @staticmethod
     def _construct_object_key(**arguments):
         """Construct object key."""

--- a/tests/storages/test_s3_gocveartifact.py
+++ b/tests/storages/test_s3_gocveartifact.py
@@ -1,0 +1,11 @@
+"""Test f8a_worker.storages.s3_gocveartifact.py."""
+
+from f8a_worker.storages.s3_gocveartifact import S3IssuesPRs
+
+
+def test_bucket_name():
+    """Test that bucket name is all in lower case."""
+    storage = S3IssuesPRs(
+        aws_access_key_id='x', aws_secret_access_key='y', bucket_name='STAGE-abc'
+    )
+    assert storage.bucket_name == 'stage-abc'


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html

Since March 1, 2018, Amazon S3 no longer supports creating bucket names
that contain uppercase letters or underscores.