### PR TITLE
Bumping up GitPython version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ flake8==3.6.0             # via flake8-polyfill
 git2json==0.2.3
 graphviz==0.10.1          # via selinon
 gitpython==2.1.11
-gitdb2 < 3.0.2
+gitdb2==3.0.1
 idna==2.7                 # via requests
 jmespath==0.9.3           # via boto3, botocore
 jsl==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,7 @@ flake8-polyfill==1.0.2    # via radon
 flake8==3.6.0             # via flake8-polyfill
 git2json==0.2.3
 graphviz==0.10.1          # via selinon
-gitpython==2.1.11
-gitdb2==3.0.1
+gitpython==3.1.0
 idna==2.7                 # via requests
 jmespath==0.9.3           # via boto3, botocore
 jsl==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ flake8==3.6.0             # via flake8-polyfill
 git2json==0.2.3
 graphviz==0.10.1          # via selinon
 gitpython==2.1.11
+gitdb2 < 3.0.2
 idna==2.7                 # via requests
 jmespath==0.9.3           # via boto3, botocore
 jsl==0.2.4


### PR DESCRIPTION
# Description
Bumping up GitPython version because of https://github.com/gitpython-developers/GitPython/issues/983 

Fixes # (issue)
[CI Build is Failing- ModuleNotFoundError: No module named 'gitdb.utils.compat'](https://ci.centos.org/job/devtools-f8a-server-backbone-fabric8-analytics/448/consoleFull).
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

