### PR TITLE
Removal of source_licenses and libraries_io tasks from ingestion flow

### DIFF
--- a/f8a_worker/dispatcher/flows/bayesianAnalysisFlow.yml
+++ b/f8a_worker/dispatcher/flows/bayesianAnalysisFlow.yml
@@ -27,15 +27,6 @@
       edges:
         - from:
           to:
-            - 'source_licenses'
-          condition:
-            not:
-              name: 'argsFieldEqual'
-              args:
-                key: 'ecosystem_backend'
-                value: 'nuget'
-        - from:
-          to:
             - 'metadata'
         - from:
           to:

--- a/f8a_worker/dispatcher/flows/bayesianPackageAnalysisFlow.yml
+++ b/f8a_worker/dispatcher/flows/bayesianPackageAnalysisFlow.yml
@@ -23,5 +23,3 @@
           to: 'RepositoryDescCollectorTask'
           condition: &repositoryDescCollectorCheck
             name: 'alwaysFalse'
-        - from:
-          to: 'libraries_io'


### PR DESCRIPTION
# Description
Removed source_licenses and libraries_io tasks from the flow, as these are not in use anymore.