### PR TITLE
fix: Incorrect github repo contributor count

### DIFF
--- a/f8a_worker/utils.py
+++ b/f8a_worker/utils.py
@@ -602,7 +602,7 @@ def peek(iterable):
 
 @retry(reraise=True, stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_fixed(1))
 def get_gh_contributors(url):
-    """Wrap requests which tries to get response.
+    """Get number of contributors from Git URL.
 
     :param url: URL where to do the request
     :return:  length of contributor's list

--- a/f8a_worker/utils.py
+++ b/f8a_worker/utils.py
@@ -619,4 +619,4 @@ def get_gh_contributors(url):
         else:
             return -1
     except HTTPError as err:
-        raise NotABugTaskError(err)
+        raise NotABugTaskError(err) from err

--- a/f8a_worker/workers/githuber.py
+++ b/f8a_worker/workers/githuber.py
@@ -55,10 +55,10 @@ class GithubTask(BaseTask):
             if url:
                 contributors = get_gh_contributors(url)
             else:
-                contributors = 0
+                contributors = -1
         except NotABugTaskError as e:
             self.log.debug(e)
-            contributors = 0
+            contributors = -1
         d = {'contributors_count': contributors}
         for prop in REPO_PROPS:
             d[prop] = repo.get(prop, -1)

--- a/f8a_worker/workers/githuber.py
+++ b/f8a_worker/workers/githuber.py
@@ -10,7 +10,8 @@ from selinon import FatalTaskError
 from f8a_worker.base import BaseTask
 from f8a_worker.errors import F8AConfigurationException, NotABugTaskError, NotABugFatalTaskError
 from f8a_worker.schemas import SchemaRef
-from f8a_worker.utils import parse_gh_repo, get_response
+from f8a_worker.utils import parse_gh_repo, get_response, get_gh_contributors
+import time
 
 REPO_PROPS = ('forks_count', 'subscribers_count', 'stargazers_count', 'open_issues_count')
 
@@ -52,13 +53,26 @@ class GithubTask(BaseTask):
         """Collect various repository properties."""
         try:
             if repo.get('contributors_url', ''):
-                contributors = get_response(repo.get('contributors_url', ''), self._headers)
+                contributors_url = repo.get('contributors_url', '')
+                page_count = 1
+                contributors = []
+
+                while True:
+                    url = contributors_url + "?per_page=100&page=" + str(page_count)
+                    contributors_batch = get_gh_contributors(url, self._headers)
+
+                    if len(contributors_batch) > 0:
+                        page_count += 1
+                        contributors.extend(contributors_batch)
+                        time.sleep(1)
+                    else:
+                        break
             else:
-                contributors = {}
+                contributors = []
         except NotABugTaskError as e:
             self.log.debug(e)
-            contributors = {}
-        d = {'contributors_count': len(list(contributors)) if contributors is not None else 'N/A'}
+
+        d = {'contributors_count': len(contributors) if contributors is not None else 'N/A'}
         for prop in REPO_PROPS:
             d[prop] = repo.get(prop, -1)
         return d

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,4 @@ vine==1.1.4               # via amqp
 watchdog==0.9.0
 werkzeug==0.14.1          # via flask
 xmltodict==0.11.0         # via anymarkup
+tenacity==6.2.0


### PR DESCRIPTION
# Description

Github API by default gives 30 contributors list, to get actual list of contributors we need to use pagination over URL. to do this added a utility function to iterate over pages unless length of list is not 0.

## Issue
APPAI-1432