### PR TITLE
fix: Define SQS_MSG_LIFETIME as oc template parameter

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -168,7 +168,7 @@ objects:
                 name: bayesian-config
                 key: auth-url
           - name: SQS_MSG_LIFETIME
-            value: "24"
+            value: "${SQS_MSG_LIFETIME}"
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           name: bayesian-worker
           readinessProbe:
@@ -287,3 +287,9 @@ parameters:
   required: false
   name: SENTRY_DSN
   value: ""
+
+- description: SQS message life time in hours
+  displayName: SQS message life time
+  required: true
+  name: SQS_MSG_LIFETIME
+  value: "24"

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -168,7 +168,7 @@ objects:
                 name: bayesian-config
                 key: auth-url
           - name: SQS_MSG_LIFETIME
-            value: 24
+            value: "24"
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           name: bayesian-worker
           readinessProbe:


### PR DESCRIPTION
# Description

As CI deployment job does not accept value of a environment variable as a Numeric type, making the value a String object. 