### PR TITLE
fix: Persist uuid into user_id column of api_requests table.

### DIFF
--- a/f8a_worker/storages/postgres.py
+++ b/f8a_worker/storages/postgres.py
@@ -213,7 +213,7 @@ class BayesianPostgres(PostgresBase):
         s3 = StoragePool.get_connected_storage('S3UserProfileStore')
         s3.store_in_bucket(content)
 
-    def store_api_requests(self, external_request_id, data, dep_data):
+    def store_api_requests(self, external_request_id, uuid_data, data, dep_data):
         """Get result of previously scheduled analysis.
 
         :param external_request_id: str, ID of analysis
@@ -246,7 +246,8 @@ class BayesianPostgres(PostgresBase):
             origin=data.get('origin', None),
             team=data.get('team', None),
             recommendation=data.get('recommendation', None),
-            request_digest=request_digest
+            request_digest=request_digest,
+            user_id=uuid_data
         )
 
         try:

--- a/f8a_worker/workers/bookkeeper.py
+++ b/f8a_worker/workers/bookkeeper.py
@@ -78,4 +78,5 @@ class BookkeeperTask(BaseTask):
 
         postgres = StoragePool.get_connected_storage('BayesianPostgres')
         postgres.store_api_requests(arguments.get('external_request_id'),
+                                    arguments.get('user_id'),
                                     arguments.get('data'), aggregated)


### PR DESCRIPTION
Now we can store uuid from CA calls into the api_requests table.