### PR TITLE
fix: Missing Github statistics.

### DIFF
--- a/f8a_worker/utils.py
+++ b/f8a_worker/utils.py
@@ -32,6 +32,7 @@ from f8a_worker.models import (Analysis,
                                Package,
                                Version)
 from f8a_worker.defaults import configuration
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -698,12 +699,14 @@ def execute_gh_queries(repo_name, start_date, end_date):
         # Get PR details based on date range provided
         pr_opened = get_gh_query_response(repo_name, '',
                                           'pr', start_date, end_date, 'created')
+        time.sleep(3)
         pr_closed = get_gh_query_response(repo_name, 'closed',
                                           'pr', start_date, end_date, 'closed')
-
+        time.sleep(3)
         # Get Issue details based on date range provided
         issues_opened = get_gh_query_response(repo_name,
                                               '', 'issue', start_date, end_date, 'created')
+        time.sleep(3)
         issues_closed = get_gh_query_response(repo_name,
                                               'closed', 'issue', start_date, end_date, 'closed')
 
@@ -728,7 +731,7 @@ def get_gh_pr_issue_counts(repo_name):
     # Get PR/Issue counts for previous month
     pr_opened_last_month, pr_closed_last_month, issues_opened_last_month, issues_closed_last_month\
         = execute_gh_queries(repo_name, last_month_start_date, last_month_end_date)
-
+    time.sleep(3)
     # Get previous year and start and end dates of year
     last_year_start_date = today - datetime.timedelta(days=365)
     last_year_end_date = today

--- a/f8a_worker/workers/githuber.py
+++ b/f8a_worker/workers/githuber.py
@@ -14,6 +14,7 @@ from f8a_worker.utils import (parse_gh_repo,
                               get_gh_contributors,
                               get_gh_pr_issue_counts)
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class GithubTask(BaseTask):
         except NotABugTaskError as e:
             self.log.debug(e)
             return []
-        return [x['total'] for x in activity]
+        return [x.get('total', 0) for x in activity]
 
     def _get_repo_stats(self, repo):
         """Collect various repository properties."""
@@ -107,6 +108,7 @@ class GithubTask(BaseTask):
         issues['license'] = repo.get('license') or {}
 
         # Get Commit Statistics
+        time.sleep(3)
         last_year_commits = self._get_last_years_commits(repo['url'])
         commits = {'last_year_commits': {'sum': sum(last_year_commits),
                                          'weekly': last_year_commits}}
@@ -116,6 +118,7 @@ class GithubTask(BaseTask):
         issues.update(commits)
 
         # Get PR/Issue details for previous Month and Year
+        time.sleep(3)
         gh_pr_issue_details = get_gh_pr_issue_counts(self._repo_name)
         issues.update(gh_pr_issue_details)
 

--- a/f8a_worker/workers/new_githuber.py
+++ b/f8a_worker/workers/new_githuber.py
@@ -14,6 +14,7 @@ from f8a_worker.utils import (parse_gh_repo,
 from f8a_utils.golang_utils import GolangUtils
 from selinon import StoragePool
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 REPO_PROPS = ('forks_count', 'subscribers_count', 'stargazers_count', 'open_issues_count')
@@ -126,6 +127,7 @@ class NewGithubTask(BaseTask):
         issues.update(commits)
 
         # Get PR/Issue details for previous Month and Year
+        time.sleep(3)
         gh_pr_issue_details = get_gh_pr_issue_counts(self._repo_name)
 
         issues.update(gh_pr_issue_details)


### PR DESCRIPTION
# Description
Due to many concurrent Github API calls are made in a very short span of time by Github Refresh job, we are facing rate limit problem. To avoid that now we are giving some delay between each Github API call.