### PR TITLE
Add App SRE build scripts and Dockerfiles

### DIFF
--- a/Dockerfile.app-sre
+++ b/Dockerfile.app-sre
@@ -1,0 +1,36 @@
+FROM quay.io/app-sre/fabric8-analytics-f8a-worker-base:aa8893d
+
+ENV LANG=en_US.UTF-8 \
+    # place where to download & unpack artifacts
+    WORKER_DATA_DIR='/var/lib/f8a_worker/worker_data' \
+    # home directory
+    HOME='/workdir' \
+    # place for alembic migrations
+    ALEMBIC_DIR='/alembic'
+
+# Make sure random user has place to store files
+RUN mkdir -p ${HOME} ${WORKER_DATA_DIR} ${ALEMBIC_DIR}/alembic/ && \
+    chmod 777 ${HOME} ${WORKER_DATA_DIR}
+WORKDIR ${HOME}
+
+COPY requirements.txt /tmp/f8a_worker/
+# Install google.protobuf from source
+# https://github.com/fabric8-analytics/fabric8-analytics-worker/issues/261
+# https://github.com/google/protobuf/issues/1296
+RUN cd /tmp/f8a_worker/ && \
+    pip3 install -r requirements.txt
+
+COPY alembic.ini hack/run-db-migrations.sh ${ALEMBIC_DIR}/
+COPY alembic/ ${ALEMBIC_DIR}/alembic
+
+# Install f8a_worker
+COPY ./ /tmp/f8a_worker/
+RUN cd /tmp/f8a_worker && pip3 install .
+
+COPY hack/worker+pmcd.sh /usr/bin/
+EXPOSE 44321
+CMD ["/usr/bin/worker+pmcd.sh"]
+
+# Make sure there are no root-owned files and directories in the home directory,
+# as this directory can be used by non-root user at runtime.
+RUN find ${HOME} -mindepth 1 -delete

--- a/Dockerfile.rhel.app-sre
+++ b/Dockerfile.rhel.app-sre
@@ -1,0 +1,36 @@
+FROM quay.io/app-sre/rhel-fabric8-analytics-f8a-worker-base:aa8893d
+
+ENV LANG=en_US.UTF-8 \
+    # place where to download & unpack artifacts
+    WORKER_DATA_DIR='/var/lib/f8a_worker/worker_data' \
+    # home directory
+    HOME='/workdir' \
+    # place for alembic migrations
+    ALEMBIC_DIR='/alembic'
+
+# Make sure random user has place to store files
+RUN mkdir -p ${HOME} ${WORKER_DATA_DIR} ${ALEMBIC_DIR}/alembic/ && \
+    chmod 777 ${HOME} ${WORKER_DATA_DIR}
+WORKDIR ${HOME}
+
+COPY requirements.txt /tmp/f8a_worker/
+# Install google.protobuf from source
+# https://github.com/fabric8-analytics/fabric8-analytics-worker/issues/261
+# https://github.com/google/protobuf/issues/1296
+RUN cd /tmp/f8a_worker/ && \
+    pip3 install -r requirements.txt
+
+COPY alembic.ini hack/run-db-migrations.sh ${ALEMBIC_DIR}/
+COPY alembic/ ${ALEMBIC_DIR}/alembic
+
+# Install f8a_worker
+COPY ./ /tmp/f8a_worker/
+RUN cd /tmp/f8a_worker && pip3 install .
+
+COPY hack/worker+pmcd.sh /usr/bin/
+EXPOSE 44321
+CMD ["/usr/bin/worker+pmcd.sh"]
+
+# Make sure there are no root-owned files and directories in the home directory,
+# as this directory can be used by non-root user at runtime.
+RUN find ${HOME} -mindepth 1 -delete

--- a/build_deploy.rhel.sh
+++ b/build_deploy.rhel.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -exv
+
+BASE_IMG="rhel-bayesian-cucos-worker"
+QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+IMG="${BASE_IMG}:latest"
+
+GIT_HASH=`git rev-parse --short=7 HEAD`
+
+# login to quay to pull base image
+DOCKER_CONF="$PWD/.docker"
+mkdir -p "$DOCKER_CONF"
+docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+
+# build the image
+docker build  --no-cache \
+              --force-rm \
+              -t ${IMG}  \
+              -f ./Dockerfile.rhel.app-sre .
+
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:${GIT_HASH}"

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -exv
+
+BASE_IMG="bayesian-cucos-worker"
+QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+IMG="${BASE_IMG}:latest"
+
+GIT_HASH=`git rev-parse --short=7 HEAD`
+
+# build the image
+docker build  --no-cache \
+              --force-rm \
+              -t ${IMG}  \
+              -f ./Dockerfile.app-sre .
+
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:${GIT_HASH}"


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/APPSRE-3082 we are migrating the service to App SRE standards.
We are duplicating the Dockerfiles to pull and push to quay.io/app-sre and this will be cleaned up in a following PR.

Thanks!