### PR TITLE
add pull secret to openshift manifest

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -8,6 +8,12 @@ metadata:
     description: bayesian-worker
 objects:
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: bayesian-worker
+  imagePullSecrets:
+  - name: ${IMAGE_PULL_SECRET_NAME}
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
@@ -191,6 +197,8 @@ objects:
               memory: ${MEMORY_LIMIT}
               cpu: ${CPU_LIMIT}
         restartPolicy: Always
+        serviceAccount: bayesian-worker
+        serviceAccountName: bayesian-worker
     test: false
     triggers:
     - type: ConfigChange
@@ -293,3 +301,8 @@ parameters:
   required: true
   name: SQS_MSG_LIFETIME
   value: "24"
+
+- description: Private pull secret name
+  displayName: Private pull secret name
+  name: IMAGE_PULL_SECRET_NAME
+  value: "quay.io"


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3082

this PR adds a ServiceAccount to the deployment manifest so that the pods can pull a private image. the pull secret is currently associated to the default ServiceAccount, and that is not a good practice.