### PR TITLE
make SA name unique in template

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -197,8 +197,8 @@ objects:
               memory: ${MEMORY_LIMIT}
               cpu: ${CPU_LIMIT}
         restartPolicy: Always
-        serviceAccount: bayesian-worker
-        serviceAccountName: bayesian-worker
+        serviceAccount: bayesian-worker-${WORKER_ADMINISTRATION_REGION}${WORKER_NAME_SUFFIX}
+        serviceAccountName: bayesian-worker-${WORKER_ADMINISTRATION_REGION}${WORKER_NAME_SUFFIX}
     test: false
     triggers:
     - type: ConfigChange

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -10,7 +10,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: bayesian-worker
+    name: bayesian-worker-${WORKER_ADMINISTRATION_REGION}${WORKER_NAME_SUFFIX}
   imagePullSecrets:
   - name: ${IMAGE_PULL_SECRET_NAME}
 - apiVersion: v1


### PR DESCRIPTION
follow up on #951 

since the same template is applied multiple times and we only allow unique resources to be applied, the SA name should be unique.