### PR TITLE
revert template SA changes

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -8,12 +8,6 @@ metadata:
     description: bayesian-worker
 objects:
 - apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: bayesian-worker-${WORKER_ADMINISTRATION_REGION}${WORKER_NAME_SUFFIX}
-  imagePullSecrets:
-  - name: ${IMAGE_PULL_SECRET_NAME}
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
@@ -197,8 +191,6 @@ objects:
               memory: ${MEMORY_LIMIT}
               cpu: ${CPU_LIMIT}
         restartPolicy: Always
-        serviceAccount: bayesian-worker-${WORKER_ADMINISTRATION_REGION}${WORKER_NAME_SUFFIX}
-        serviceAccountName: bayesian-worker-${WORKER_ADMINISTRATION_REGION}${WORKER_NAME_SUFFIX}
     test: false
     triggers:
     - type: ConfigChange
@@ -301,8 +293,3 @@ parameters:
   required: true
   name: SQS_MSG_LIFETIME
   value: "24"
-
-- description: Private pull secret name
-  displayName: Private pull secret name
-  name: IMAGE_PULL_SECRET_NAME
-  value: "quay.io"


### PR DESCRIPTION
the changes introduced will not work since the pre hook pod of the DeploymentConfig is only using the default SA, which doesn't have pull credentials.

we will need to take a different route (new PR incoming).