### PR TITLE
add imagePullSecrets to DeploymentConfig

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -191,6 +191,8 @@ objects:
               memory: ${MEMORY_LIMIT}
               cpu: ${CPU_LIMIT}
         restartPolicy: Always
+        imagePullSecrets:
+        - name: ${IMAGE_PULL_SECRET_NAME}
     test: false
     triggers:
     - type: ConfigChange
@@ -293,3 +295,8 @@ parameters:
   required: true
   name: SQS_MSG_LIFETIME
   value: "24"
+
+- description: Private pull secret name
+  displayName: Private pull secret name
+  name: IMAGE_PULL_SECRET_NAME
+  value: "quay.io"


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3082

to allow all pods created by a DeploymentConfig to pull private images, we need to add this section to the template. using a ServiceAccount does not work because the pre hook pod is using the default SA and this is not overridable (AFAIK).